### PR TITLE
v0.2: mobile-first cards, wider inputs, resize-aware render

### DIFF
--- a/app.js
+++ b/app.js
@@ -447,7 +447,7 @@ function render() {
     <td>${escape(plan.compound.focus)}</td>
     <td>${plan.compound.sets}</td>
     <td>${escape(plan.compound.repsRange)}</td>
-    <td><input type="text" data-type="weight" data-index="compound" placeholder="${escape(plan.compound.weight)}" /></td>
+    <td><input type="text" class="starting-weight-input" data-type="weight" data-index="compound" placeholder="${escape(plan.compound.weight)}" /></td>
     <td>${escape(plan.compound.notes)}</td>
   </tr>`);
   // Accessory rows
@@ -457,13 +457,30 @@ function render() {
       <td>${escape(acc.focus)}</td>
       <td>${acc.sets}</td>
       <td>${escape(acc.repsRange)}</td>
-      <td><input type="text" data-type="weight" data-index="${idx}" placeholder="${escape(acc.weight)}" /></td>
+      <td><input type="text" class="starting-weight-input" data-type="weight" data-index="${idx}" placeholder="${escape(acc.weight)}" /></td>
       <td>${escape(acc.notes)}</td>
     </tr>`);
   });
+
+  // Build cards for mobile view
+  const cards = [];
+  const pushCard = (ex, idx) => {
+    cards.push(`
+      <div class="exercise-card">
+        <h4>${escape(ex.exercise)}</h4>
+        <div class="exercise-meta">${escape(ex.focus)} – ${ex.sets} x ${escape(ex.repsRange)}</div>
+        <input type="text" class="starting-weight-input" data-type="weight" data-index="${idx}" placeholder="${escape(ex.weight)}" />
+        ${ex.notes ? `<div class="exercise-notes">${escape(ex.notes)}</div>` : ''}
+      </div>
+    `);
+  };
+  pushCard(plan.compound, 'compound');
+  plan.accessories.forEach((acc, idx) => pushCard(acc, idx));
+  const cardsHTML = cards.join('');
+
   // Compose the full HTML for the workout table
   const tableHTML = `
-    <table>
+    <table class="table">
       <thead>
         <tr>
           <th>Exercise</th>
@@ -520,7 +537,8 @@ function render() {
       </div>
       <p class="italic mb-2">${escape(plan.affirmation)}</p>
       <p>${t('warmup')}</p>
-      ${tableHTML}
+      <div id="planTable">${tableHTML}</div>
+      <div id="planCards" aria-live="polite">${cardsHTML}</div>
       <p>${t('cooldown')}</p>
       <div id="finisherSection">
         <select id="finisherSelect">${finisherOptions}</select>
@@ -662,15 +680,19 @@ function exportCSV() {
   const rows = [];
   // CSV header
   rows.push(['Exercise', 'Focus', 'Sets', 'Reps', 'Weight', 'Notes'].join(','));
-  // Gather data from table inputs
+  // Gather data from weight inputs (table or cards)
   const inputs = document.querySelectorAll('input[data-type="weight"]');
   const seed = appState.seedWeek + hashCode(appState.dayKey);
   const plan = generateDailyPlan(appState.dayKey, appState.level, seed);
   // Build array of exercise objects in order: compound then accessories
   const exObjects = [plan.compound, ...plan.accessories];
+  const weightMap = {};
+  inputs.forEach((input) => {
+    weightMap[input.dataset.index] = input.value || '';
+  });
   exObjects.forEach((ex, idx) => {
-    const input = inputs[idx];
-    const weight = input && input.value ? input.value : '';
+    const key = idx === 0 ? 'compound' : String(idx - 1);
+    const weight = weightMap[key] || '';
     rows.push([
       escapeForCSV(ex.exercise),
       escapeForCSV(ex.focus),
@@ -717,5 +739,10 @@ if (typeof window !== 'undefined' && window.addEventListener) {
         .register('/service-worker.js')
         .catch((error) => console.error('Service worker registration failed:', error));
     }
+  });
+  let resizeTimeout;
+  window.addEventListener('resize', () => {
+    clearTimeout(resizeTimeout);
+    resizeTimeout = setTimeout(render, 200);
   });
 }

--- a/index.html
+++ b/index.html
@@ -25,7 +25,10 @@
   </head>
   <body>
     <!-- The root element into which the application will render. -->
-    <div id="app"></div>
+    <div id="app">
+      <div id="planTable"></div>
+      <div id="planCards" aria-live="polite"></div>
+    </div>
     <!--
       Load the application script. The ``defer`` attribute ensures the
       script executes only after the HTML is parsed. All application logic

--- a/style.css
+++ b/style.css
@@ -98,6 +98,14 @@ select {
   font-size: 0.9rem;
 }
 
+input.starting-weight-input {
+  min-width: 140px;
+}
+
+#planCards {
+  display: none;
+}
+
 label {
   font-size: 0.9rem;
   font-weight: 500;
@@ -149,4 +157,45 @@ footer {
 #timerContainer {
   font-size: 2rem;
   text-align: center;
+}
+
+@media (max-width: 640px) {
+  .table {
+    display: none;
+  }
+
+  #planCards {
+    display: block;
+  }
+
+  .exercise-card {
+    border: 1px solid #e5e7eb;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    background: #ffffff;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  }
+
+  .exercise-card h4 {
+    margin: 0 0 0.5rem;
+    font-size: 1rem;
+  }
+
+  .exercise-meta {
+    font-size: 0.875rem;
+    color: #374151;
+    margin-bottom: 0.5rem;
+  }
+
+  .exercise-notes {
+    font-size: 0.875rem;
+    color: #374151;
+  }
+
+  .starting-weight-input {
+    width: 100%;
+    height: 44px;
+    padding: 0.5rem;
+    font-size: 1rem;
+  }
 }


### PR DESCRIPTION
## Summary
- Add mobile-friendly exercise cards that appear below the table and show name, meta, starting weight, and notes
- Widen starting weight inputs and style them for mobile screens
- Re-render plans on window resize for responsive updates

## Testing
- `node tests/test.js`


------
https://chatgpt.com/codex/tasks/task_e_68979f60df3c8327b07e3fba7ca5ff64