### PR TITLE
fix: equalize mobile padding and prevent overflow

### DIFF
--- a/app.js
+++ b/app.js
@@ -498,7 +498,7 @@ function render() {
   `;
   // Build the checklist
   const checklistHTML = `
-    <div>
+    <div id="checklistSection">
       <h3>${t('checklistTitle')}</h3>
       <label><input type="checkbox" data-check="water" /> ${t('checklistWater')}</label><br />
       <label><input type="number" min="0" max="12" step="0.5" data-check="sleep" placeholder="${t('checklistSleep')}" /> </label><br />

--- a/style.css
+++ b/style.css
@@ -8,6 +8,13 @@
   units where possible to better adapt to different screen sizes.
 */
 
+/* Ensure padding is included in element width calculations */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
 html, body {
   height: 100%;
   margin: 0;
@@ -149,6 +156,12 @@ footer {
 }
 
 /* Finisher list and timer */
+#finisherSection,
+#checklistSection {
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
 #finisherSection ul {
   list-style: none;
   padding-left: 0;


### PR DESCRIPTION
## Summary
- ensure padding uses border-box to avoid overflow on mobile
- add horizontal padding for finisher and checklist sections for consistent layout
- mark checklist section with an ID for targeted styling

## Testing
- `node tests/test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897a69cd56083279064c0eb75470f21