### PR TITLE
feat(style): add workout style selection with persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,30 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
+    <div id="styleScreen" class="style-screen" aria-labelledby="styleScreenTitle" role="dialog">
+      <h2 id="styleScreenTitle">Choose Your Workout Style</h2>
+      <p class="style-subtitle">Pick how you want to train today. You can change this anytime.</p>
+      <div class="style-grid">
+        <button class="style-card" data-style="home" aria-label="Home Workout">
+          <div class="style-card-title">Home Workout</div>
+          <div class="style-card-desc">Bodyweight + DB/KB. Minimal gear.</div>
+        </button>
+        <button class="style-card" data-style="gym" aria-label="Gym Workout">
+          <div class="style-card-title">Gym Workout</div>
+          <div class="style-card-desc">Full equipment. Barbell/Machines OK.</div>
+        </button>
+        <button class="style-card" data-style="cardio" aria-label="Cardio">
+          <div class="style-card-title">Cardio</div>
+          <div class="style-card-desc">25–40 min steady or intervals.</div>
+        </button>
+        <button class="style-card" data-style="recovery" aria-label="Active Recovery">
+          <div class="style-card-title">Active Recovery</div>
+          <div class="style-card-desc">Mobility + easy movement.</div>
+        </button>
+      </div>
+    </div>
     <!-- The root element into which the application will render. -->
-    <div id="app">
+    <div id="app" class="hidden">
       <div id="planTable"></div>
       <div id="planCards" aria-live="polite"></div>
     </div>

--- a/style.css
+++ b/style.css
@@ -201,3 +201,73 @@ footer {
 
 }
 
+/* Style selection screen */
+.style-screen {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 16px;
+  box-sizing: border-box;
+}
+.style-subtitle {
+  color: #475569;
+  margin: 6px 0 12px;
+}
+.style-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.style-card {
+  display: block;
+  width: 100%;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 14px;
+  background: #fff;
+  text-align: left;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.04);
+}
+.style-card:focus {
+  outline: 3px solid #93c5fd;
+  outline-offset: 2px;
+}
+.style-card-title {
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-bottom: 4px;
+  color: #0b3d91;
+}
+.style-card-desc {
+  color: #475569;
+  font-size: 0.95rem;
+}
+
+/* Mobile first */
+@media (max-width: 480px) {
+  .style-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Change Style link button */
+.link-btn {
+  background: transparent;
+  color: #0b3d91;
+  border: none;
+  text-decoration: underline;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+/* Ensure main container respects equal horizontal padding */
+.container {
+  padding-left: 16px;
+  padding-right: 16px;
+  box-sizing: border-box;
+}
+
+/* Hide/show screens helper */
+.hidden {
+  display: none !important;
+}
+


### PR DESCRIPTION
## Summary
- add workout style picker screen to choose Home, Gym, Cardio or Active Recovery and persist choice
- wire header with selected style tag and Change Style link; route between screens
- adapt generator for home minimal equipment, cardio and recovery templates

## Testing
- `node tests/test.js`


------
https://chatgpt.com/codex/tasks/task_e_6897a78406a88327b2c29eb12f8fd471