### PR TITLE
Expose push/pull/leg workouts and add hamburger menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ mobile‑ready.
 * **6‑day Push–Pull–Legs Hybrid** – A structured weekly program with
   compound and accessory movements. The plan automatically rotates
   exercises to avoid overuse.
+* **Selectable gym formats** – Choose between Push, Pull or Leg templates
+  directly in the session.
 * **Daily plan generator** – Generates a warm‑up, main workout table
   (exercise, focus, sets, reps, starting weight and notes), a mandatory
   7‑minute finisher and a cooldown. Each day includes an affirmation.
@@ -23,6 +25,8 @@ mobile‑ready.
 * **Checklist & logging** – Users can tick off hydration, sleep, warm‑up
   and pump, record their RPE and mood, and enter starting weights per
   exercise. Data can be exported as CSV for analysis.
+* **Hamburger menu** – Settings and language selection are tucked away to
+  preserve the app’s branding.
 * **Offline support** – A service worker caches static assets so the app
   functions offline once installed. It can be installed to a device
   home screen like a native app.

--- a/index.html
+++ b/index.html
@@ -10,13 +10,17 @@
   <header class="appbar">
     <div class="appbar__title" data-i18n="appTitle">Yodha Arc — Forge Your Steel</div>
     <div class="appbar__actions">
-      <select id="languageSelect" aria-label="Language">
-        <option value="en">English</option>
-        <option value="te">తెలుగు</option>
-      </select>
-      <button id="btnSettings" class="icon-btn" aria-label="Settings" title="Settings">⚙️</button>
+      <button id="btnMenu" class="icon-btn" aria-label="Menu" title="Menu">☰</button>
     </div>
   </header>
+
+  <nav id="menu" class="menu" hidden>
+    <select id="languageSelect" aria-label="Language">
+      <option value="en">English</option>
+      <option value="te">తెలుగు</option>
+    </select>
+    <button id="btnSettings" class="btn menu-item" data-i18n="settings">Settings</button>
+  </nav>
 
   <main id="app" class="container">
     <!-- Screen 0: Splash / Login -->
@@ -69,6 +73,14 @@
         <button class="link" id="linkChangeStyle" data-i18n="changeStyle">Change style</button>
       </div>
       <p class="sub" data-i18n="gymWarmup">Warm-up (8–10 min): joint prep + ramp sets for the compound.</p>
+      <div class="row mt">
+        <label for="formatSelect">Workout:</label>
+        <select id="formatSelect">
+          <option value="pull">Pull</option>
+          <option value="push">Push</option>
+          <option value="legs">Legs</option>
+        </select>
+      </div>
       <div id="gymPlan" class="stack"></div>
       <h3 class="headline mt" data-i18n="finisherTitle">Superman Finisher</h3>
       <p class="sub" data-i18n="finisherSub">7-minute loop: 15 Jumping Jacks → 12 Swings → 10 DB Snatches (5/arm) → 20 Mountain Climbers.</p>

--- a/styles.css
+++ b/styles.css
@@ -28,8 +28,11 @@ body {
 }
 .appbar__title { font-weight: 700; }
 .appbar__actions { display:flex; align-items:center; gap:8px; }
-.appbar select { height:32px; border-radius:6px; }
 .icon-btn { background: transparent; color:#fff; border:0; font-size: 20px; cursor:pointer; }
+
+.menu { position:absolute; top:56px; right:12px; background:#fff; border:1px solid #e5e7eb; border-radius:8px; padding:8px; box-shadow:0 2px 8px rgba(0,0,0,.1); display:flex; flex-direction:column; gap:8px; }
+.menu select { height:32px; border-radius:6px; }
+.menu .menu-item { width:100%; }
 
 /* Screens */
 .screen { padding: 16px 0; }


### PR DESCRIPTION
## Summary
- Replace header actions with hamburger menu housing language and settings
- Support Push, Pull and Leg gym templates selectable from session screen
- Implement simple deterministic daily plan generator for tests

## Testing
- `node tests/test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f242e9d308327a776fe9a63b4df2e