### PR TITLE
Refine mobile welcome layout with slide-out menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -124,10 +124,14 @@ function initLang() {
 function initMenu() {
   const menu = doc.getElementById('menu');
   const btn = doc.getElementById('btnMenu');
-  if (!menu || !btn) return;
-  btn.addEventListener('click', () => {
-    menu.hidden = !menu.hidden;
-  });
+  const overlay = doc.getElementById('menuOverlay');
+  if (!menu || !btn || !overlay) return;
+  const toggle = () => {
+    const open = menu.classList.toggle('open');
+    overlay.classList.toggle('show', open);
+  };
+  btn.addEventListener('click', toggle);
+  overlay.addEventListener('click', toggle);
 }
 
 // Screen switching

--- a/index.html
+++ b/index.html
@@ -14,7 +14,8 @@
     </div>
   </header>
 
-  <nav id="menu" class="menu" hidden>
+  <div id="menuOverlay" class="menu-overlay"></div>
+  <nav id="menu" class="menu">
     <select id="languageSelect" aria-label="Language">
       <option value="en">English</option>
       <option value="te">తెలుగు</option>

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,12 @@
 * { box-sizing: border-box; }
+:root { --header-height:56px; --footer-height:40px; }
 html, body { height: 100%; }
 body {
   margin: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
   font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Nirmala UI";
   color: #0f172a;
   background: #f7fafc;
@@ -10,7 +15,8 @@ body {
   max-width: 760px;
   margin-inline: auto;
   padding-inline: 16px;  /* equal left/right padding */
-  padding-bottom: 64px;
+  height: calc(100vh - var(--header-height) - var(--footer-height));
+  overflow-y: auto;
 }
 @supports (padding: max(0px)) {
   .container {
@@ -23,19 +29,23 @@ body {
 .appbar {
   position: sticky; top: 0; z-index: 10;
   display: flex; align-items: center; justify-content: space-between;
-  height: 56px; padding: 0 12px;
+  height: var(--header-height); padding: 0 12px;
   background: #0b3d91; color: #fff; border-bottom: 1px solid #0a357f;
 }
 .appbar__title { font-weight: 700; }
 .appbar__actions { display:flex; align-items:center; gap:8px; }
 .icon-btn { background: transparent; color:#fff; border:0; font-size: 20px; cursor:pointer; }
 
-.menu { position:absolute; top:56px; right:12px; background:#fff; border:1px solid #e5e7eb; border-radius:8px; padding:8px; box-shadow:0 2px 8px rgba(0,0,0,.1); display:flex; flex-direction:column; gap:8px; }
+.menu-overlay { position:fixed; inset:0; background:rgba(0,0,0,0.4); opacity:0; visibility:hidden; transition:opacity 0.3s; z-index:15; }
+.menu-overlay.show { opacity:1; visibility:visible; }
+.menu { position:fixed; top:0; right:0; height:100vh; width:240px; background:#fff; box-shadow:-2px 0 8px rgba(0,0,0,.1); padding:16px; display:flex; flex-direction:column; gap:12px; transform:translateX(100%); transition:transform 0.3s ease; z-index:20; }
+.menu.open { transform:translateX(0); }
 .menu select { height:32px; border-radius:6px; }
 .menu .menu-item { width:100%; }
 
 /* Screens */
 .screen { padding: 16px 0; }
+#screen-welcome { min-height:100%; display:flex; flex-direction:column; justify-content:center; }
 .logo {
   width: 84px; height: 84px; border-radius: 50%;
   background: #0b3d91; color:#fff; display: grid; place-items: center;
@@ -84,6 +94,10 @@ body {
 .exercise__meta { color:#334155; font-size:14px; }
 .exercise__notes { color:#475569; font-size:13px; margin-top:6px; }
 
-.footer { text-align:center; padding:20px 16px; color:#64748b; }
+.footer {
+  position:fixed; bottom:0; left:0; width:100%; height:var(--footer-height);
+  display:flex; align-items:center; justify-content:center;
+  color:#64748b;
+}
 .or { text-align:center; color:#94a3b8; }
 .footnote { color:#94a3b8; font-size:12px; }


### PR DESCRIPTION
## Summary
- Add sliding hamburger menu with language selector and settings
- Fix header and footer layout for full-viewport mobile experience
- Center welcome screen content to avoid vertical scrolling

## Testing
- `node tests/test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f27c8e64c832788173888e7c64968