### PR TITLE
Implement router and fixed layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,71 +7,43 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <header class="appbar">
-    <div class="appbar__title" data-i18n="appTitle">Yodha Arc — Forge Your Steel</div>
-    <div class="appbar__actions">
-      <button id="btnMenu" class="icon-btn" aria-label="Menu" title="Menu">☰</button>
-    </div>
-  </header>
+    <header class="appbar">
+      <div class="appbar__title" data-i18n="appTitle">Yodha Arc — Forge Your Steel</div>
+      <div class="appbar__actions">
+        <button id="btnMenu" class="icon-btn" aria-label="Menu" title="Menu">☰</button>
+      </div>
+    </header>
 
-  <div id="menuOverlay" class="menu-overlay"></div>
-  <nav id="menu" class="menu">
-    <select id="languageSelect" aria-label="Language">
-      <option value="en">English</option>
-      <option value="te">తెలుగు</option>
-    </select>
-    <button id="btnSettings" class="btn menu-item" data-i18n="settings">Settings</button>
-  </nav>
+    <div id="menuOverlay" class="menu-overlay"></div>
+    <nav id="menu" class="menu">
+      <button id="btnMenuClose" class="icon-btn menu__close" aria-label="Close menu">✕</button>
+      <select id="languageSelect" aria-label="Language">
+        <option value="en">English</option>
+        <option value="te">తెలుగు</option>
+      </select>
+      <button id="btnSettings" class="btn menu-item" data-i18n="settings">Settings</button>
+    </nav>
 
-  <main id="app" class="container">
-    <!-- Screen 0: Splash / Login -->
-    <section id="screen-splash" class="screen" data-screen="splash" hidden>
-      <div class="logo">Yodha</div>
-      <h1 class="headline" data-i18n="welcome">Welcome</h1>
-      <p class="sub" data-i18n="splashSub">Sign in or continue as guest to start training.</p>
-      <div class="stack">
-        <button id="btnGoogle" class="btn btn-primary" data-i18n="splashGoogle">Continue with Google (mock)</button>
-        <div class="or" data-i18n="splashOr">or</div>
-        <div class="row">
-          <input id="nameInput" class="input" placeholder="Your name" autocomplete="name" data-i18n-placeholder="splashNamePlaceholder" />
-          <button id="btnGuest" class="btn btn-secondary" data-i18n="splashContinue">Continue</button>
+    <main id="app" class="viewport">
+      <!-- Welcome -->
+      <section id="screen-welcome" class="screen" data-screen="welcome">
+        <h2 id="welcomeTitle" class="headline"></h2>
+        <div class="card stats">
+          <div class="stat"><div class="stat__label" data-i18n="streak">Streak</div><div id="streakVal" class="stat__value">0</div></div>
+          <div class="stat"><div class="stat__label" data-i18n="lastWorkout">Last workout</div><div id="lastWorkoutVal" class="stat__value">—</div></div>
+          <div class="stat"><div class="stat__label" data-i18n="time">Time (IST)</div><div id="timeVal" class="stat__value">—</div></div>
         </div>
-      </div>
-      <p class="footnote" data-i18n="splashFootnote">MVP: Local-only. No server. Data stays on this device.</p>
-    </section>
+        <div class="stack mt">
+          <button id="btnChooseStyle" class="btn btn-primary" data-i18n="chooseStyle">Choose Workout Style</button>
+          <button id="btnContinueLast" class="btn btn-ghost"><span data-i18n="continueLast">Continue last:</span> <span id="lastStyleChip">—</span></button>
+        </div>
+      </section>
 
-    <!-- Screen 1: Welcome / Dashboard -->
-    <section id="screen-welcome" class="screen" data-screen="welcome" hidden>
-      <h2 id="welcomeTitle" class="headline"></h2>
-      <div class="card stats">
-        <div class="stat"><div class="stat__label" data-i18n="streak">Streak</div><div id="streakVal" class="stat__value">0</div></div>
-        <div class="stat"><div class="stat__label" data-i18n="lastWorkout">Last workout</div><div id="lastWorkoutVal" class="stat__value">—</div></div>
-        <div class="stat"><div class="stat__label" data-i18n="time">Time (IST)</div><div id="timeVal" class="stat__value">—</div></div>
-      </div>
-      <div class="stack mt">
-        <button id="btnChooseStyle" class="btn btn-primary" data-i18n="chooseStyle">Choose Workout Style</button>
-        <button id="btnContinueLast" class="btn btn-ghost"><span data-i18n="continueLast">Continue last:</span> <span id="lastStyleChip">—</span></button>
-      </div>
-    </section>
-
-    <!-- Screen 2: Style Selection -->
-    <section id="screen-style" class="screen" data-screen="style" hidden>
-      <h2 class="headline" data-i18n="styleHeadline">How do you want to train today?</h2>
-      <p class="sub" data-i18n="styleSub">Pick one. You can change this anytime.</p>
-      <div class="grid">
-        <button class="style-card" data-style="gym"><div class="style-title" data-i18n="styleGymTitle">Gym Workout</div><div class="style-desc" data-i18n="styleGymDesc">Full equipment. Barbell/Machines OK.</div></button>
-        <button class="style-card" data-style="home"><div class="style-title" data-i18n="styleHomeTitle">Home Workout</div><div class="style-desc" data-i18n="styleHomeDesc">Bodyweight + DB/KB. Minimal gear.</div></button>
-        <button class="style-card" data-style="cardio"><div class="style-title" data-i18n="styleCardioTitle">Cardio</div><div class="style-desc" data-i18n="styleCardioDesc">25–40 min steady or intervals.</div></button>
-        <button class="style-card" data-style="recovery"><div class="style-title" data-i18n="styleRecoveryTitle">Active Recovery</div><div class="style-desc" data-i18n="styleRecoveryDesc">Mobility + easy movement.</div></button>
-      </div>
-      <button id="btnStyleBack" class="btn btn-ghost mt" data-i18n="back">Back</button>
-    </section>
-
-    <!-- Screen 3: Gym Session -->
-    <section id="screen-gym" class="screen" data-screen="gym" hidden>
-      <div class="row between">
-        <h2 class="headline" data-i18n="gymSessionTitle">Today’s Gym Session</h2>
-        <button class="link" id="linkChangeStyle" data-i18n="changeStyle">Change style</button>
+      <!-- Gym Session -->
+      <section id="screen-gym" class="screen" data-screen="gym" hidden>
+        <div class="row between">
+          <h2 class="headline" data-i18n="gymSessionTitle">Today’s Gym Session</h2>
+          <button class="link" id="linkChangeStyle" data-i18n="changeStyle">Change style</button>
       </div>
       <p class="sub" data-i18n="gymWarmup">Warm-up (8–10 min): joint prep + ramp sets for the compound.</p>
       <div class="row mt">
@@ -93,14 +65,32 @@
           <button id="btnResetTimer" class="btn btn-ghost" data-i18n="reset">Reset</button>
         </div>
       </div>
-      <div class="stack mt">
-        <button id="btnMarkDone" class="btn btn-success" data-i18n="markDone">Mark workout complete</button>
-        <button id="btnBackHome" class="btn btn-ghost" data-i18n="back">Back</button>
-      </div>
-    </section>
-  </main>
+        <div class="stack mt">
+          <button id="btnMarkDone" class="btn btn-success" data-i18n="markDone">Mark workout complete</button>
+          <button id="btnBackHome" class="btn btn-ghost" data-i18n="back">Back</button>
+        </div>
+      </section>
+    </main>
 
-  <footer class="footer">© 2025 Yodha Arc</footer>
-  <script src="app.js"></script>
-</body>
-</html>
+    <!-- Style selection modal -->
+    <div id="styleModal" class="style-modal" hidden>
+      <h2 class="headline" data-i18n="styleHeadline">How do you want to train today?</h2>
+      <p class="sub" data-i18n="styleSub">Pick one. You can change this anytime.</p>
+      <label for="levelSelect" class="mt">Level:</label>
+      <select id="levelSelect" class="mt">
+        <option value="Intermediate">Intermediate</option>
+        <option value="Advanced">Advanced</option>
+      </select>
+      <div class="grid mt">
+        <button class="style-card" data-style="gym"><div class="style-title" data-i18n="styleGymTitle">Gym Workout</div><div class="style-desc" data-i18n="styleGymDesc">Full equipment. Barbell/Machines OK.</div></button>
+        <button class="style-card" data-style="home"><div class="style-title" data-i18n="styleHomeTitle">Home Workout</div><div class="style-desc" data-i18n="styleHomeDesc">Bodyweight + DB/KB. Minimal gear.</div></button>
+        <button class="style-card" data-style="cardio"><div class="style-title" data-i18n="styleCardioTitle">Cardio</div><div class="style-desc" data-i18n="styleCardioDesc">25–40 min steady or intervals.</div></button>
+        <button class="style-card" data-style="recovery"><div class="style-title" data-i18n="styleRecoveryTitle">Active Recovery</div><div class="style-desc" data-i18n="styleRecoveryDesc">Mobility + easy movement.</div></button>
+      </div>
+      <button id="styleClose" class="btn btn-ghost mt" data-i18n="back">Back</button>
+    </div>
+
+    <footer class="footer">© 2025 Yodha Arc</footer>
+    <script src="app.js"></script>
+  </body>
+  </html>

--- a/styles.css
+++ b/styles.css
@@ -1,36 +1,36 @@
 * { box-sizing: border-box; }
 :root { --header-height:56px; --footer-height:40px; }
-html, body { height: 100%; }
+html, body { height:100%; overflow:hidden; }
 body {
-  margin: 0;
-  height: 100vh;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
+  margin:0;
+  height:100%;
   font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Nirmala UI";
-  color: #0f172a;
-  background: #f7fafc;
+  color:#0f172a;
+  background:#f7fafc;
 }
-.container {
-  max-width: 760px;
-  margin-inline: auto;
-  padding-inline: 16px;  /* equal left/right padding */
-  height: calc(100vh - var(--header-height) - var(--footer-height));
-  overflow-y: auto;
+.viewport {
+  position:fixed;
+  top:var(--header-height);
+  left:0; right:0;
+  height:calc(100dvh - var(--header-height) - var(--footer-height));
+  overflow:hidden;
+  max-width:760px;
+  margin-inline:auto;
+  padding-inline:16px;
 }
 @supports (padding: max(0px)) {
-  .container {
-    padding-left: max(16px, env(safe-area-inset-left));
-    padding-right: max(16px, env(safe-area-inset-right));
+  .viewport {
+    padding-left:max(16px, env(safe-area-inset-left));
+    padding-right:max(16px, env(safe-area-inset-right));
   }
 }
 
 /* App bar */
 .appbar {
-  position: sticky; top: 0; z-index: 10;
-  display: flex; align-items: center; justify-content: space-between;
-  height: var(--header-height); padding: 0 12px;
-  background: #0b3d91; color: #fff; border-bottom: 1px solid #0a357f;
+  position:fixed; top:0; left:0; right:0; z-index:10;
+  display:flex; align-items:center; justify-content:space-between;
+  height:var(--header-height); padding:0 12px;
+  background:#0b3d91; color:#fff; border-bottom:1px solid #0a357f;
 }
 .appbar__title { font-weight: 700; }
 .appbar__actions { display:flex; align-items:center; gap:8px; }
@@ -38,14 +38,15 @@ body {
 
 .menu-overlay { position:fixed; inset:0; background:rgba(0,0,0,0.4); opacity:0; visibility:hidden; transition:opacity 0.3s; z-index:15; }
 .menu-overlay.show { opacity:1; visibility:visible; }
-.menu { position:fixed; top:0; right:0; height:100vh; width:240px; background:#fff; box-shadow:-2px 0 8px rgba(0,0,0,.1); padding:16px; display:flex; flex-direction:column; gap:12px; transform:translateX(100%); transition:transform 0.3s ease; z-index:20; }
+.menu { position:fixed; top:0; right:0; height:100dvh; width:240px; background:#fff; box-shadow:-2px 0 8px rgba(0,0,0,.1); padding:16px; display:flex; flex-direction:column; gap:12px; transform:translateX(100%); transition:transform 0.3s ease; z-index:20; }
 .menu.open { transform:translateX(0); }
 .menu select { height:32px; border-radius:6px; }
 .menu .menu-item { width:100%; }
+.menu__close { align-self:flex-end; background:transparent; border:0; font-size:20px; cursor:pointer; }
 
 /* Screens */
-.screen { padding: 16px 0; }
-#screen-welcome { min-height:100%; display:flex; flex-direction:column; justify-content:center; }
+.screen { padding:16px 0; height:100%; overflow-y:auto; }
+#screen-welcome { display:flex; flex-direction:column; justify-content:center; overflow:hidden; }
 .logo {
   width: 84px; height: 84px; border-radius: 50%;
   background: #0b3d91; color:#fff; display: grid; place-items: center;
@@ -94,10 +95,22 @@ body {
 .exercise__meta { color:#334155; font-size:14px; }
 .exercise__notes { color:#475569; font-size:13px; margin-top:6px; }
 
-.footer {
-  position:fixed; bottom:0; left:0; width:100%; height:var(--footer-height);
-  display:flex; align-items:center; justify-content:center;
-  color:#64748b;
+.style-modal {
+  position:fixed;
+  top:var(--header-height);
+  bottom:var(--footer-height);
+  left:0; right:0;
+  background:#fff;
+  z-index:30;
+  overflow-y:auto;
+  padding:16px;
 }
+
+  .footer {
+    position:fixed; bottom:0; left:0; width:100%; height:var(--footer-height);
+    display:flex; align-items:center; justify-content:center;
+    color:#64748b;
+    background:#f7fafc;
+  }
 .or { text-align:center; color:#94a3b8; }
 .footnote { color:#94a3b8; font-size:12px; }


### PR DESCRIPTION
## Summary
- Ensure only one screen renders at a time with a simple `activate` router
- Add style selection modal with level choice and last-style resume
- Fix header/footer layout and add right-side hamburger menu with language and settings

## Testing
- `node tests/test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f2b11a7848327929668ecfb500afc