### PR TITLE
Polish custom planner workflow and add preview server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,123 +1,100 @@
-# Yodha Arc – Cavill Physique Coach (MVP)
+# Yodha Arc — Adaptive Training Arc
 
-Welcome to **Yodha Arc**, a lightweight progressive web application (PWA) that
-guides users towards a Henry‑Cavill‑style physique: strong, lean and
-athletic. This repository contains a complete, working minimum viable
-product written in vanilla JavaScript. The app generates daily workouts,
-tracks progress and provides nutrition guidance—all offline‑friendly and
-mobile‑ready.
+Yodha Arc is a fully client-side coaching experience that rotates gym, home
+and outdoor sessions while letting athletes build precision “muscle sculpt”
+days directly on an interactive anatomy map. The interface guides users
+through a cinematic welcome, environment selection, level tuning and plan
+review so every training day feels intentional and fresh.
 
-## Features
+## Feature Highlights
 
-* **6‑day Push–Pull–Legs Hybrid** – A structured weekly program with
-  compound and accessory movements. The plan automatically rotates
-  exercises to avoid overuse.
-* **Selectable gym formats** – Choose between Push, Pull or Leg templates
-  directly in the session.
-* **Daily plan generator** – Generates a warm‑up, main workout table
-  (exercise, focus, sets, reps, starting weight and notes), a mandatory
-  7‑minute finisher and a cooldown. Each day includes an affirmation.
-* **Weekly seed rotation** – Workout variations remain consistent within a week and refresh each new week.
-* **Level & language selection** – Supports Beginner/Intermediate levels and
-  English/Telugu copy. A header dropdown lets users switch languages and the
-  selection persists across sessions.
-* **Finisher library** – Select default, bodyweight or low‑impact finishers with a move‑aware 7‑minute timer.
-* **Checklist & logging** – Users can tick off hydration, sleep, warm‑up
-  and pump, record their RPE and mood, and enter starting weights per
-  exercise. Data can be exported as CSV for analysis.
-* **Hamburger menu** – Settings and language selection are tucked away to
-  preserve the app’s branding.
-* **Offline support** – A service worker caches static assets so the app
-  functions offline once installed. It can be installed to a device
-  home screen like a native app.
-* **Testing** – A simple Node test harness validates the workout
-  generator logic.
+- **Guided stepper workflow** – A four-step flow (welcome → environment →
+  profile → session) keeps the user anchored, with automatic focus and
+  smooth scrolling to the active card.
+- **Custom muscle sculptor** – Tap up to three muscle groups on the neon
+  anatomy map to generate bespoke PPL-style sessions. Selection status and a
+  clear button keep editing frictionless, and plans refresh immediately as
+  choices change.
+- **Environment-aware templates** – Gym, home and outdoor templates rotate
+  volume/size phases, enforce the 70-minute cap and finish every day with a
+  mandatory seven-move HIIT burst.
+- **Auto level promotion** – Completing 30 Beginner sessions unlocks
+  Intermediate, and 40 more unlock Advanced. Session counters reset after
+  each promotion so users keep progressing.
+- **Daily intelligence** – The dashboard tracks streaks, the last style
+  used, a feedback-fed history log and a main-lift progress graph built from
+  logged weights.
+- **Persistent feedback loop** – Every session stores feedback (“too easy”,
+  “just right”, “too tough”), optional notes and load entries so tomorrow’s
+  intensity bias adapts automatically.
 
-## Repository Structure
+## Project Layout
 
 ```
 yodha-arc/
-├── index.html        — entry point; minimal HTML linking styles and scripts
-├── app.js            — application logic (translations, state, generator, UI)
-├── style.css         — base styling for a clean, modern interface
-├── manifest.json     — PWA manifest describing icons, colours and display
-├── service-worker.js — offline caching logic
-├── icon-192.png      — application icon (192×192)
-├── icon-512.png      — application icon (512×512)
+├── app.js            # Planner logic, storage, UI controller and muscle map
+├── index.html        # Multi-step interface shell
+├── styles.css        # Neon gradient visual system and responsive layout
+├── preview.js        # Zero-dependency static preview server
+├── package.json      # npm scripts for previewing and testing
+├── manifest.json     # PWA manifest
+├── service-worker.js # Offline cache bootstrap
+├── icon-192.png      # App icon (192×192)
+├── icon-512.png      # App icon (512×512)
 ├── tests/
-│   └── test.js       — minimal test harness for generator functions
-└── README.md         — this document
+│   └── test.js       # Node assertions for planner invariants
+└── README.md         # This document
 ```
 
-## Running Locally
+## Previewing the Experience
 
-You do not need any external package manager (like npm) to run this app; it
-is written in pure HTML/JS/CSS. To serve it locally with a simple HTTP
-server:
+A lightweight preview server is bundled so you can review the exact build
+before committing or shipping changes.
 
+```bash
+npm install    # optional – there are no runtime deps
+npm run preview
 ```
-cd yodha-arc
-python3 -m http.server 8000
+
+By default the server listens on <http://localhost:4173>. Set the `PORT`
+environment variable to override it:
+
+```bash
+PORT=5000 npm run preview
 ```
 
-Then navigate to [`http://localhost:8000`](http://localhost:8000) in your
-browser. If you open the app directly from the file system (e.g. by
-double‑clicking `index.html`), some browsers will disallow the service
-worker. Serving over HTTP solves this.
+Stop the server at any time with `Ctrl+C`.
+
+If you prefer not to use npm you can invoke the script directly:
+
+```bash
+node preview.js
+```
 
 ## Running Tests
 
-Node is available in the environment. To run the tests that validate the
-workout generator logic:
+All generator and scheduling rules are validated through a small Node test
+suite:
 
+```bash
+npm test
+# or
+node tests/test.js
 ```
-cd yodha-arc/tests
-node test.js
-```
 
-All assertions should pass. You can add additional tests by extending
-`tests/test.js`.
+The tests confirm the 70-minute cap, HIIT finisher, rotation variety,
+calisthenics availability and the custom muscle selector’s three-muscle
+limit.
 
-## Deploying / Shipping
+## Extending Further
 
-Because the application is a collection of static files, it can be hosted
-almost anywhere:
+- Introduce authentication or cloud sync so athletes can resume progress on
+  any device.
+- Layer in form videos or technique cues for the custom builder’s exercises.
+- Add structured deload weeks and strength progressions keyed to the stored
+  intensity feedback.
+- Export logs as CSV/JSON so lifters can take their data into external
+  analytics tools.
 
-* **GitHub Pages** – After pushing this repository to GitHub, enable
-  GitHub Pages for the `main` branch (`/root` directory). The app will be
-  available at `https://<username>.github.io/<repository>/`.
-* **Vercel / Netlify** – Create a new project and point it at your GitHub
-  repository. Use the default static site settings (no build step) so
-  Vercel/Netlify simply serve the `index.html`.
-* **Firebase Hosting** – Initialise Firebase hosting and run
-  `firebase deploy` to upload the static files.
-
-Any hosting platform that can serve static assets over HTTPS will work. The
-important part for PWA installation is that the site is served from a
-secure origin (`https`), so opening `index.html` directly from disk will
-not allow installation.
-
-## Contributing & Extending
-
-This MVP is designed to be a foundation. Here are some ideas for
-extending it:
-
-* **IndexedDB persistence** – Replace the simple `localStorage` with
-  IndexedDB (via Dexie.js) to store complete training history, body
-  measurements, photos and nutrition logs.
-* **Charting** – Use a lightweight library (like Chart.js) to display
-  moving average trends for weight and protein intake.
-* **Notifications** – Integrate the Notifications API to send daily
-  reminders at 5:00 AM IST.
-* **Video cues** – Add embedded technique videos and form cues for each
-  exercise.
-* **Automatic deloading & progression** – Implement the progression
-  logic described in the specification to adjust weights and sets based on
-  user performance and recovery signals.
-
-## Licensing
-
-This project is provided for educational purposes. You are free to use
-it as a starting point for your own fitness app. All content, including
-affirmations and exercise descriptions, can be modified to suit your
-requirements.
+The project is intentionally dependency-light and modular (OOP services for
+profile, library and planner logic) to make experimentation painless.

--- a/app.js
+++ b/app.js
@@ -1,297 +1,1478 @@
-// Client-only state + navigation for MVP
+/*
+ * Yodha Arc — Advanced adaptive workout platform with custom muscle builder.
+ * The architecture uses small classes to keep responsibilities clear:
+ *  - StorageService handles persistence.
+ *  - ProfileManager tracks user level progression and feedback.
+ *  - WorkoutLibrary exposes all exercise catalogs.
+ *  - PlanGenerator builds day-specific training plans (gym/home/outdoor/custom).
+ *  - MuscleSelector + PlannerUI manage the interface workflow when running in the browser.
+ */
+
 const doc = typeof document !== 'undefined' ? document : null;
-const $ = doc ? (s) => doc.querySelector(s) : () => null;
-const $$ = doc ? (s) => Array.from(doc.querySelectorAll(s)) : () => [];
-const save = (k, v) => localStorage.setItem(k, JSON.stringify(v));
-const load = (k, d=null) => { try { return JSON.parse(localStorage.getItem(k)); } catch { return d; } };
-const fmtTime = (d) => d.toLocaleTimeString('en-IN', { hour: '2-digit', minute: '2-digit', timeZone: 'Asia/Kolkata' });
 
-const STATE = {
-  user: load('user') || { name: 'Warrior' },
-  style: load('style'),                 // 'gym' | 'home' | 'cardio' | 'recovery'
-  lastWorkoutISO: load('lastWorkoutISO'),
-  streak: load('streak') || 0,
-  lang: load('lang') || 'en',
-  format: load('format') || 'pull',     // 'pull' | 'push' | 'legs'
-  level: load('level') || 'Intermediate'
+/* -------------------------------------------------------------------------- */
+/* Storage and state helpers                                                   */
+/* -------------------------------------------------------------------------- */
+
+class StorageService {
+  constructor(adapter) {
+    this.adapter = adapter || (typeof localStorage !== 'undefined' ? localStorage : null);
+  }
+
+  load(key, fallback = null) {
+    if (!this.adapter) return fallback;
+    try {
+      const raw = this.adapter.getItem(key);
+      return raw ? JSON.parse(raw) : fallback;
+    } catch (error) {
+      console.warn('Failed loading key', key, error);
+      return fallback;
+    }
+  }
+
+  save(key, value) {
+    if (!this.adapter) return;
+    try {
+      this.adapter.setItem(key, JSON.stringify(value));
+    } catch (error) {
+      console.warn('Failed saving key', key, error);
+    }
+  }
+}
+
+const storageService = new StorageService();
+
+/* -------------------------------------------------------------------------- */
+/* Core data catalog                                                           */
+/* -------------------------------------------------------------------------- */
+
+const MOTIVATIONAL_QUOTES = [
+  'Discipline carves the warrior you wish to become.',
+  'Steel is forged under pressure—so are you.',
+  'Consistency beats intensity when intensity is inconsistent.',
+  'Today’s volume becomes tomorrow’s confidence.',
+  'You do not rise to the level of your goals, you fall to the level of your rituals.',
+  'Every rep is a receipt for the future you are buying.'
+];
+
+const HIIT_LIBRARY = [
+  ['Battle rope slams', 'Burpee broad jumps', 'Kettlebell snatches', 'Mountain climbers', 'Skater hops', 'Plank shoulder taps', 'High knees sprint'],
+  ['Rowing sprint', 'Box jump overs', 'Medicine ball slams', 'Jump lunges', 'Push-up jacks', 'Hollow body rocks', 'Speed skaters'],
+  ['Jump rope sprint', 'Lateral bounds', 'Thrusters', 'Bear crawl', 'Tuck jumps', 'Russian twists', 'Sprint in place'],
+  ['Alternating kettlebell cleans', 'Boxer shuffle punches', 'Squat jump reach', 'Sprawl to row', 'Sprint ladder', 'Alternating V-ups', 'Plank jacks'],
+];
+
+const CALISTHENICS_MOVES = [
+  { name: 'Ring rows', note: 'Gym/Home/Outdoor' },
+  { name: 'Archer push-ups', note: 'Progressive strength' },
+  { name: 'Pistol squat to box', note: 'Control depth' },
+  { name: 'Hanging leg raises', note: 'Brace hard' },
+  { name: 'Handstand hold', note: 'Kick-up or wall supported' },
+  { name: 'Parallel bar dips', note: 'Slow tempo' },
+  { name: 'Copenhagen plank', note: 'Adductors + core' },
+  { name: 'Support hold', note: 'Rings or dip bars' },
+];
+
+const GOAL_FOCUS = {
+  strength: ['Compound priority', 'Longer rest', 'Lower rep top sets'],
+  hypertrophy: ['Mind-muscle connection', 'Moderate rest', 'Higher accessory volume'],
+  fatloss: ['Paired circuits', 'Reduced rest', 'Keep heart rate high'],
+  endurance: ['Tempo management', 'Breathing focus', 'RPE 7–8 sustained'],
 };
 
-const STRINGS = {
-  en: {
-    appTitle: 'Yodha Arc — Forge Your Steel',
-    welcome: 'Welcome',
-    splashSub: 'Sign in or continue as guest to start training.',
-    splashGoogle: 'Continue with Google (mock)',
-    splashOr: 'or',
-    splashNamePlaceholder: 'Your name',
-    splashContinue: 'Continue',
-    splashFootnote: 'MVP: Local-only. No server. Data stays on this device.',
-    streak: 'Streak',
-    lastWorkout: 'Last workout',
-    time: 'Time (IST)',
-    chooseStyle: 'Choose Workout Style',
-    continueLast: 'Continue last:',
-    styleHeadline: 'How do you want to train today?',
-    styleSub: 'Pick one. You can change this anytime.',
-    styleGymTitle: 'Gym Workout',
-    styleGymDesc: 'Full equipment. Barbell/Machines OK.',
-    styleHomeTitle: 'Home Workout',
-    styleHomeDesc: 'Bodyweight + DB/KB. Minimal gear.',
-    styleCardioTitle: 'Cardio',
-    styleCardioDesc: '25–40 min steady or intervals.',
-    styleRecoveryTitle: 'Active Recovery',
-    styleRecoveryDesc: 'Mobility + easy movement.',
-    back: 'Back',
-    gymSessionTitle: 'Today’s Gym Session',
-    changeStyle: 'Change style',
-    gymWarmup: 'Warm-up (8–10 min): joint prep + ramp sets for the compound.',
-    finisherTitle: 'Superman Finisher',
-    finisherSub: '7-minute loop: 15 Jumping Jacks → 12 Swings → 10 DB Snatches (5/arm) → 20 Mountain Climbers.',
-    start: 'Start',
-    pause: 'Pause',
-    reset: 'Reset',
-    markDone: 'Mark workout complete',
-    settings: 'Settings'
+const LEVEL_THRESHOLDS = {
+  Beginner: 30,
+  Intermediate: 40,
+};
+
+/* -------------------------------------------------------------------------- */
+/* Libraries for guided plans                                                 */
+/* -------------------------------------------------------------------------- */
+
+const GYM_LIBRARY = {
+  push: {
+    volume: [
+      { name: 'Barbell Bench Press', sets: 3, reps: '6–8', type: 'compound', main: true },
+      { name: 'Incline Dumbbell Press', sets: 3, reps: '10–12' },
+      { name: 'Seated Shoulder Press', sets: 3, reps: '8–10' },
+      { name: 'Cable Fly', sets: 2, reps: '15–20' },
+      { name: 'Overhead Triceps Extension', sets: 2, reps: '12–15' },
+    ],
+    size: [
+      { name: 'Paused Bench Press', sets: 4, reps: '5', type: 'compound', main: true },
+      { name: 'Machine Chest Press', sets: 4, reps: '10' },
+      { name: 'Arnold Press', sets: 4, reps: '10–12' },
+      { name: 'Cable Lateral Raise', sets: 4, reps: '15' },
+      { name: 'Rope Pressdowns', sets: 3, reps: '12–15' },
+    ],
   },
-  te: {
-    appTitle: 'యోధ ఆర్క్ — మీ ఉక్కును మలచుకోండి',
-    welcome: 'స్వాగతం',
-    splashSub: 'ట్రైనింగ్ ప్రారంభించడానికి సైన్ ఇన్ చేయండి లేదా గెస్ట్‌గా కొనసాగండి.',
-    splashGoogle: 'గూగుల్‌తో కొనసాగండి (మాక్)',
-    splashOr: 'లేదా',
-    splashNamePlaceholder: 'మీ పేరు',
-    splashContinue: 'కొనసాగించు',
-    splashFootnote: 'MVP: స్థానిక-మాత్రం. సర్వర్ లేదు. డేటా ఈ పరికరంలోనే ఉంటుంది.',
-    streak: 'సీరిస్',
-    lastWorkout: 'చివరి వ్యాయామం',
-    time: 'సమయం (IST)',
-    chooseStyle: 'వ్యాయామ శైలి ఎంచుకోండి',
-    continueLast: 'గతదాన్ని కొనసాగించు:',
-    styleHeadline: 'ఈరోజు మీరు ఎలా వ్యాయామం చేయాలనుకుంటున్నారు?',
-    styleSub: 'ఒకదాన్ని ఎంచుకోండి. మీరు ఇది ఎప్పుడైనా మార్చవచ్చు.',
-    styleGymTitle: 'జిమ్ వ్యాయామం',
-    styleGymDesc: 'పూర్తి సామగ్రి. బార్‌బెల్/మెషీన్లు సరే.',
-    styleHomeTitle: 'ఇంటి వ్యాయామం',
-    styleHomeDesc: 'బాడీవెయిట్ + డంబెల్/కెటిల్‌బెల్. కనిష్ట సామగ్రి.',
-    styleCardioTitle: 'కార్డియో',
-    styleCardioDesc: '25–40 నిమిషాల మోడరేట్ లేదా ఇంటర్వెల్స్.',
-    styleRecoveryTitle: 'సక్రియ పునరుద్ధరణ',
-    styleRecoveryDesc: 'సంచలన మరియు సులభ కదలిక.',
-    back: 'తిరిగి',
-    gymSessionTitle: 'ఈరోజు జిమ్ సెషన్',
-    changeStyle: 'శైలిని మార్చు',
-    gymWarmup: 'వార్మ్-అప్ (8–10 నిమి): కీళ్ళ సిద్ధత + సంయుక్త కోసం ర్యాంప్ సెట్లు.',
-    finisherTitle: 'సూపర్‌మాన్ ముగింపు',
-    finisherSub: '7-నిమిషాల లూప్: 15 జంపింగ్ జాక్స్ → 12 స్వింగ్స్ → 10 డీబీ స్నాచెస్ (5/చేతి) → 20 మౌంటైన్ క్లైంబర్స్.',
-    start: 'ప్రారంభించు',
-    pause: 'విరమించు',
-    reset: 'రిసెట్',
-    markDone: 'వ్యాయామాన్ని పూర్తిగా గుర్తించు',
-    settings: 'సెట్టింగ్స్'
-  }
+  pull: {
+    volume: [
+      { name: 'Conventional Deadlift', sets: 3, reps: '4–6', type: 'compound', main: true },
+      { name: 'Weighted Pull-up', sets: 3, reps: '6–8' },
+      { name: 'Chest-supported Row', sets: 3, reps: '10–12' },
+      { name: 'Face Pull', sets: 2, reps: '15–20' },
+      { name: 'Incline Curl', sets: 2, reps: '12–15' },
+    ],
+    size: [
+      { name: 'Deficit Deadlift', sets: 4, reps: '5', type: 'compound', main: true },
+      { name: 'Lat Pulldown (neutral)', sets: 4, reps: '10' },
+      { name: 'Cable Row', sets: 4, reps: '12' },
+      { name: 'Reverse Pec Deck', sets: 3, reps: '15' },
+      { name: 'Preacher Curl', sets: 3, reps: '12–15' },
+    ],
+  },
+  legs: {
+    volume: [
+      { name: 'Back Squat', sets: 3, reps: '6–8', type: 'compound', main: true },
+      { name: 'Romanian Deadlift', sets: 3, reps: '8–10' },
+      { name: 'Walking Lunges', sets: 3, reps: '12/leg' },
+      { name: 'Leg Curl', sets: 2, reps: '15' },
+      { name: 'Standing Calf Raise', sets: 3, reps: '15–20' },
+    ],
+    size: [
+      { name: 'Front Squat', sets: 4, reps: '5', type: 'compound', main: true },
+      { name: 'Hack Squat', sets: 4, reps: '10' },
+      { name: 'Bulgarian Split Squat', sets: 4, reps: '10/leg' },
+      { name: 'Nordic Curl', sets: 3, reps: '6–8' },
+      { name: 'Seated Calf Raise', sets: 4, reps: '15' },
+    ],
+  },
 };
 
-function applyLang() {
-  if (!doc) return;
-  const lang = STATE.lang;
-  doc.documentElement.lang = lang;
-  $$('[data-i18n]').forEach(el => {
-    const key = el.getAttribute('data-i18n');
-    if (STRINGS[lang][key]) el.textContent = STRINGS[lang][key];
-  });
-  $$('[data-i18n-placeholder]').forEach(el => {
-    const key = el.getAttribute('data-i18n-placeholder');
-    if (STRINGS[lang][key]) el.setAttribute('placeholder', STRINGS[lang][key]);
-  });
-  const wt = $('#welcomeTitle');
-  if (wt && STATE.user.name) {
-    wt.textContent = `${STRINGS[lang].welcome}, ${STATE.user.name}!`;
-  }
-}
-
-function initLang() {
-  if (!doc) return;
-  const sel = doc.getElementById('languageSelect');
-  if (!sel) return;
-  sel.value = STATE.lang;
-  sel.addEventListener('change', () => {
-    STATE.lang = sel.value;
-    save('lang', STATE.lang);
-    applyLang();
-  });
-  applyLang();
-}
-
-function initMenu() {
-  const menu = doc.getElementById('menu');
-  const btn = doc.getElementById('btnMenu');
-  const overlay = doc.getElementById('menuOverlay');
-  const close = doc.getElementById('btnMenuClose');
-  if (!menu || !btn || !overlay) return;
-  const open = () => { menu.classList.add('open'); overlay.classList.add('show'); };
-  const hide = () => { menu.classList.remove('open'); overlay.classList.remove('show'); };
-  btn.addEventListener('click', open);
-  overlay.addEventListener('click', hide);
-  if (close) close.addEventListener('click', hide);
-}
-
-// Screen switching
-function activate(id) {
-  $$('.screen').forEach(s => s.hidden = true);
-  const el = $(id);
-  if (el) el.hidden = false;
-  window.scrollTo({ top: 0, behavior: 'instant' });
-}
-
-// Splash
-// Removed splash/login for simplified router
-
-// Welcome
-function toWelcome() {
-  activate('#screen-welcome');
-  document.getElementById('welcomeTitle').textContent = `${STRINGS[STATE.lang].welcome}, ${STATE.user.name}!`;
-  document.getElementById('timeVal').textContent = fmtTime(new Date());
-
-  const last = STATE.lastWorkoutISO ? STATE.lastWorkoutISO.slice(0,10) : null;
-  document.getElementById('streakVal').textContent = STATE.streak;
-  document.getElementById('lastWorkoutVal').textContent = last ? new Date(STATE.lastWorkoutISO).toDateString() : '—';
-  document.getElementById('lastStyleChip').textContent = STATE.style ? `${STATE.style} (${STATE.level})` : '—';
-
-  document.getElementById('btnChooseStyle').onclick = () => showStyleModal();
-  document.getElementById('btnContinueLast').onclick = () => {
-    if (!STATE.style) return showStyleModal();
-    if (STATE.style === 'gym') toGym();
-    else { alert(`${STATE.style} coming soon. Routing to Gym for MVP.`); toGym(); }
-  };
-}
-
-// Style modal
-function initStyleModal(){
-  const modal = $('#styleModal');
-  if (!modal) return;
-  const levelSel = $('#levelSelect');
-  levelSel.value = STATE.level;
-  levelSel.addEventListener('change', () => { STATE.level = levelSel.value; save('level', STATE.level); });
-  $('#styleClose').onclick = () => modal.hidden = true;
-  $$('#styleModal .style-card').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const style = btn.getAttribute('data-style');
-      STATE.style = style; save('style', style);
-      STATE.level = levelSel.value; save('level', STATE.level);
-      modal.hidden = true;
-      if (style === 'gym') toGym();
-      else { alert(`${style} coming soon. Routing to Gym for MVP.`); toGym(); }
-    });
-  });
-}
-function showStyleModal(){ const m = $('#styleModal'); if (m) m.hidden = false; }
-
-// Gym plan (MVP)
-const GYM_TEMPLATES = {
-  pull: [
-    { name: 'Deadlift', meta: 'Strength — 4 × 3–6; back-off 6–10', notes: 'Controlled tempo, 2–3s negative, 1–2 min rest' },
-    { name: 'Bent Over Row', meta: 'Back — 3 × 8–12', notes: 'Hinge position, control descent; rest 45–90s' },
-    { name: 'Pull-ups / Lat Pulldown', meta: 'Back — 3 × 8–12', notes: 'Full stretch, strong contraction; rest 45–90s' },
-    { name: 'Face Pulls', meta: 'Rear Delts — 3 × 15–20', notes: 'Squeeze shoulder blades; rest 45–90s' },
-    { name: 'Barbell Curl', meta: 'Biceps — 3 × 8–12', notes: 'No swinging, 3s negative; rest 45–90s' },
-  ],
-  push: [
-    { name: 'Bench Press', meta: 'Chest — 4 × 6–8', notes: 'Controlled descent; rest 1–2 min' },
-    { name: 'Overhead Press', meta: 'Shoulders — 3 × 8–12', notes: 'Full lockout; rest 45–90s' },
-    { name: 'Incline DB Press', meta: 'Upper Chest — 3 × 8–12', notes: 'Squeeze at top; rest 45–90s' },
-    { name: 'Lateral Raises', meta: 'Shoulders — 3 × 15–20', notes: 'Light weight, high reps; rest 30–60s' },
-    { name: 'Triceps Pushdown', meta: 'Triceps — 3 × 8–12', notes: 'Elbows tucked; rest 45–90s' },
-  ],
-  legs: [
-    { name: 'Back Squat', meta: 'Strength — 4 × 3–6; back-off 6–10', notes: 'Depth below parallel; rest 2–3 min' },
-    { name: 'Romanian Deadlift', meta: 'Hamstrings — 3 × 8–12', notes: 'Hinge at hips; rest 1–2 min' },
-    { name: 'Leg Press', meta: 'Quads — 3 × 10–15', notes: 'Full range; rest 1–2 min' },
-    { name: 'Walking Lunges', meta: 'Legs — 3 × 12/leg', notes: 'Long steps; rest 1–2 min' },
-    { name: 'Calf Raises', meta: 'Calves — 4 × 12–20', notes: 'Pause at top; rest 45–60s' },
-  ]
+const HOME_LIBRARY = {
+  minimal: {
+    total: [
+      { name: 'Tempo Push-up', sets: 3, reps: '12–15', main: true },
+      { name: 'Chair Step-up', sets: 3, reps: '12/leg' },
+      { name: 'Hip Bridge March', sets: 3, reps: '15' },
+      { name: 'Pike Shoulder Tap', sets: 2, reps: '12' },
+      { name: 'Hollow Hold', sets: 3, reps: '40s' },
+    ],
+  },
+  dumbbell: {
+    upper: [
+      { name: 'Single-arm Row', sets: 3, reps: '12/side', main: true },
+      { name: 'Floor Press', sets: 3, reps: '10–12' },
+      { name: 'Half-kneeling Press', sets: 3, reps: '12/side' },
+      { name: 'Reverse Fly', sets: 3, reps: '15' },
+      { name: 'Hammer Curl', sets: 3, reps: '12' },
+    ],
+    lower: [
+      { name: 'Goblet Squat', sets: 3, reps: '12', main: true },
+      { name: 'Romanian Deadlift', sets: 3, reps: '10' },
+      { name: 'Split Squat', sets: 3, reps: '12/leg' },
+      { name: 'DB Swing', sets: 3, reps: '20' },
+      { name: 'Calf Raise', sets: 4, reps: '20' },
+    ],
+  },
+  calisthenics: {
+    flow: CALISTHENICS_MOVES,
+  },
 };
-function renderGymPlan() {
-  const plan = GYM_TEMPLATES[STATE.format] || [];
-  const root = document.getElementById('gymPlan'); root.innerHTML = '';
-  plan.forEach(ex => {
-    const sec = document.createElement('section');
-    sec.className = 'exercise';
-    sec.innerHTML = `
-      <div class="exercise__title">${ex.name}</div>
-      <div class="exercise__meta">${ex.meta}</div>
-      <input class="input mt" placeholder="Starting weight (kg)" inputmode="decimal" />
-      <div class="exercise__notes">${ex.notes}</div>
-    `;
-    root.appendChild(sec);
-  });
-}
-function initFormat() {
-  const sel = document.getElementById('formatSelect');
-  if (!sel) return;
-  sel.value = STATE.format;
-  sel.addEventListener('change', () => {
-    STATE.format = sel.value;
-    save('format', STATE.format);
-    renderGymPlan();
-  });
-}
-function toGym(){
-  activate('#screen-gym');
-  const sel = document.getElementById('formatSelect');
-  if (sel) sel.value = STATE.format;
-  renderGymPlan();
-  document.getElementById('linkChangeStyle').onclick = showStyleModal;
-}
 
-// Finisher timer (7:00 strict)
-let timerId = null, remaining = 7*60;
-function updateTimerDisplay(){
-  const m = String(Math.floor(remaining/60)).padStart(2,'0');
-  const s = String(remaining%60).padStart(2,'0');
-  document.getElementById('timerDisplay').textContent = `${m}:${s}`;
-}
-function startTimer(){ if (timerId) return; timerId = setInterval(()=>{ remaining=Math.max(0,remaining-1); updateTimerDisplay(); if(remaining===0) pauseTimer(); },1000); }
-function pauseTimer(){ if (timerId){ clearInterval(timerId); timerId=null; } }
-function resetTimer(){ pauseTimer(); remaining=7*60; updateTimerDisplay(); }
-function initTimer(){ updateTimerDisplay(); document.getElementById('btnStartTimer').onclick=startTimer; document.getElementById('btnPauseTimer').onclick=pauseTimer; document.getElementById('btnResetTimer').onclick=resetTimer; }
+const OUTDOOR_LIBRARY = {
+  running: {
+    plan: [
+      { name: 'Dynamic stride drills', sets: 1, reps: '10 min', main: true },
+      { name: 'Interval Run', sets: 6, reps: '400m @ 5k pace' },
+      { name: 'Easy Jog Recovery', sets: 6, reps: '200m walk' },
+      { name: 'Hill Bounds', sets: 5, reps: '20s' },
+    ],
+  },
+  swimming: {
+    plan: [
+      { name: '200m easy warm-up', sets: 1, reps: '1x', main: true },
+      { name: '8 × 50m kick', sets: 8, reps: 'Moderate' },
+      { name: '6 × 100m pull buoy', sets: 6, reps: 'Threshold' },
+      { name: '200m cool-down', sets: 1, reps: 'Relaxed' },
+    ],
+  },
+  calisthenics: {
+    plan: CALISTHENICS_MOVES,
+  },
+};
 
-// Completion
-function initCompletion(){
-  document.getElementById('btnMarkDone').onclick = () => {
-    const now = new Date();
-    STATE.lastWorkoutISO = now.toISOString(); save('lastWorkoutISO', STATE.lastWorkoutISO);
-    const today = now.toISOString().slice(0,10);
-    const lastStamp = load('streakDate');
-    if (lastStamp !== today) { STATE.streak += 1; save('streak', STATE.streak); localStorage.setItem('streakDate', today); }
-    alert('Workout saved. Steel forged.');
-    toWelcome();
-  };
-  document.getElementById('btnBackHome').onclick = toWelcome;
-}
+const EQUIPMENT_VARIANTS = {
+  gym: ['freeweight', 'machines', 'calisthenics'],
+  home: ['minimal', 'dumbbell', 'calisthenics'],
+  outdoor: ['running', 'swimming', 'calisthenics'],
+};
 
-// Boot
-function boot(){
-  initStyleModal();
-  initTimer();
-  initCompletion();
-  initMenu();
-  initLang();
-  initFormat();
-  toWelcome();
-}
-if (doc) doc.addEventListener('DOMContentLoaded', boot);
+const CUSTOM_EQUIPMENT_OPTIONS = ['freeweight', 'machines', 'dumbbell', 'minimal', 'running', 'swimming', 'calisthenics'];
 
-function generateDailyPlan(dayKey, level, seed = 1){
-  const valid = ['FoundationA','FoundationB','FoundationC','DetailA','DetailB','DetailC'];
-  if (!valid.includes(dayKey)) throw new Error('Unknown day');
-  const accessoriesCount = level === 'Intermediate' ? 5 : 4;
-  const compoundSets = level === 'Intermediate' ? 4 : 3;
+/* Custom muscle library: each muscle group offers exercises across contexts */
+const CUSTOM_LIBRARY = {
+  chest: {
+    label: 'Chest',
+    category: 'push',
+    gym: [
+      { name: 'Flat Barbell Press', sets: 4, reps: '6–8', main: true },
+      { name: 'Incline Dumbbell Press', sets: 3, reps: '8–12' },
+      { name: 'Cable Fly', sets: 3, reps: '12–15' },
+    ],
+    home: [
+      { name: 'Feet-elevated Push-up', sets: 4, reps: '12' },
+      { name: 'Pseudo Planche Push-up', sets: 3, reps: '8–10' },
+      { name: 'Resistance Band Fly', sets: 3, reps: '15' },
+    ],
+    outdoor: [
+      { name: 'Parallel Bar Dips', sets: 4, reps: '8–12', main: true },
+      { name: 'Push-up Ladder', sets: 3, reps: 'Max reps' },
+      { name: 'Explosive Clap Push-up', sets: 3, reps: '10' },
+    ],
+  },
+  shoulders: {
+    label: 'Shoulders',
+    category: 'push',
+    gym: [
+      { name: 'Seated DB Shoulder Press', sets: 4, reps: '8–10', main: true },
+      { name: 'Cable Lateral Raise', sets: 4, reps: '12–15' },
+      { name: 'Rear Delt Fly', sets: 3, reps: '15' },
+    ],
+    home: [
+      { name: 'Pike Push-up', sets: 4, reps: '10–12', main: true },
+      { name: 'Band Lateral Raise', sets: 3, reps: '15' },
+      { name: 'Wall Handstand Hold', sets: 3, reps: '30s' },
+    ],
+    outdoor: [
+      { name: 'Handstand Walk Practice', sets: 4, reps: '20m' },
+      { name: 'Parallel Bar Support Hold', sets: 3, reps: '40s' },
+      { name: 'Band Face Pull', sets: 3, reps: '20' },
+    ],
+  },
+  triceps: {
+    label: 'Triceps',
+    category: 'push',
+    gym: [
+      { name: 'Close-grip Bench Press', sets: 4, reps: '6–8' },
+      { name: 'Cable Rope Pressdown', sets: 4, reps: '12–15' },
+      { name: 'Overhead EZ Extension', sets: 3, reps: '10–12' },
+    ],
+    home: [
+      { name: 'Bench Dips', sets: 4, reps: '15' },
+      { name: 'Diamond Push-up', sets: 3, reps: '12–15' },
+      { name: 'Band Overhead Extension', sets: 3, reps: '20' },
+    ],
+    outdoor: [
+      { name: 'Ring Push-down', sets: 3, reps: '12–15' },
+      { name: 'Bodyweight Skull Crusher', sets: 3, reps: '10–12' },
+      { name: 'Bench Dip Iso Hold', sets: 3, reps: '30s' },
+    ],
+  },
+  back: {
+    label: 'Back',
+    category: 'pull',
+    gym: [
+      { name: 'Deadlift', sets: 4, reps: '5', main: true },
+      { name: 'Weighted Pull-up', sets: 4, reps: '6–8' },
+      { name: 'Chest-supported Row', sets: 4, reps: '10–12' },
+    ],
+    home: [
+      { name: 'Inverted Row', sets: 4, reps: '12' },
+      { name: 'Backpack Romanian Deadlift', sets: 3, reps: '15' },
+      { name: 'Band Pulldown', sets: 3, reps: '20' },
+    ],
+    outdoor: [
+      { name: 'Towel Pull-up', sets: 4, reps: 'Max' },
+      { name: 'Horizontal Row Bar', sets: 3, reps: '12–15' },
+      { name: 'Sprint Sled Row', sets: 3, reps: '30m' },
+    ],
+  },
+  biceps: {
+    label: 'Biceps',
+    category: 'pull',
+    gym: [
+      { name: 'Barbell Curl', sets: 4, reps: '8–10' },
+      { name: 'Incline Dumbbell Curl', sets: 3, reps: '10–12' },
+      { name: 'Cable Curl Drop-set', sets: 3, reps: '15' },
+    ],
+    home: [
+      { name: 'Band Curl', sets: 4, reps: '15' },
+      { name: 'Backpack Curl', sets: 3, reps: '12' },
+      { name: 'Isometric Curl Hold', sets: 3, reps: '30s' },
+    ],
+    outdoor: [
+      { name: 'Suspension Trainer Curl', sets: 3, reps: '12' },
+      { name: 'Bar Hang Curl', sets: 3, reps: '10' },
+      { name: 'Partner Curl', sets: 2, reps: 'AMRAP' },
+    ],
+  },
+  forearms: {
+    label: 'Forearms',
+    category: 'pull',
+    gym: [
+      { name: 'Reverse Curl', sets: 3, reps: '12–15' },
+      { name: 'Farmer Carry', sets: 4, reps: '40m' },
+      { name: 'Cable Wrist Curl', sets: 3, reps: '20' },
+    ],
+    home: [
+      { name: 'Towel Grip Dead Hang', sets: 4, reps: '30s' },
+      { name: 'Rice Bucket Twist', sets: 3, reps: '1 min' },
+      { name: 'Backpack Hammer Curl', sets: 3, reps: '15' },
+    ],
+    outdoor: [
+      { name: 'Rope Climb Practice', sets: 4, reps: '10m' },
+      { name: 'Thick Bar Carry', sets: 3, reps: '30m' },
+      { name: 'Sandbag Wrist Flexion', sets: 3, reps: '20' },
+    ],
+  },
+  core: {
+    label: 'Core',
+    category: 'accessory',
+    gym: [
+      { name: 'Cable Woodchop', sets: 4, reps: '12/side' },
+      { name: 'Weighted Plank', sets: 3, reps: '60s' },
+      { name: 'Hanging Leg Raise', sets: 4, reps: '10–12' },
+    ],
+    home: [
+      { name: 'Dragon Flag', sets: 3, reps: '6–8' },
+      { name: 'Side Plank Reach', sets: 3, reps: '45s' },
+      { name: 'Hollow Body Rock', sets: 3, reps: '20' },
+    ],
+    outdoor: [
+      { name: 'L-sit on Parallel Bars', sets: 4, reps: '30s' },
+      { name: 'Hanging Knee Raise', sets: 3, reps: '15' },
+      { name: 'Med-ball Russian Twist', sets: 3, reps: '20' },
+    ],
+  },
+  glutes: {
+    label: 'Glutes',
+    category: 'legs',
+    gym: [
+      { name: 'Barbell Hip Thrust', sets: 4, reps: '8–10', main: true },
+      { name: 'Cable Kickback', sets: 3, reps: '15' },
+      { name: 'Walking Lunge', sets: 3, reps: '12/leg' },
+    ],
+    home: [
+      { name: 'Single-leg Glute Bridge', sets: 4, reps: '12/side' },
+      { name: 'Band Monster Walk', sets: 3, reps: '20 steps' },
+      { name: 'Rear-foot Elevated Split Squat', sets: 3, reps: '12/leg' },
+    ],
+    outdoor: [
+      { name: 'Hill Sprint', sets: 8, reps: '10s', main: true },
+      { name: 'Sandbag Carry', sets: 4, reps: '40m' },
+      { name: 'Step-up Bench', sets: 3, reps: '15/leg' },
+    ],
+  },
+  quads: {
+    label: 'Quads',
+    category: 'legs',
+    gym: [
+      { name: 'Back Squat', sets: 4, reps: '5–8', main: true },
+      { name: 'Leg Press', sets: 4, reps: '12' },
+      { name: 'Leg Extension', sets: 3, reps: '15' },
+    ],
+    home: [
+      { name: 'Pistol Squat to Box', sets: 4, reps: '6/leg' },
+      { name: 'Split Squat Pulse', sets: 3, reps: '15/leg' },
+      { name: 'Jump Squat', sets: 3, reps: '12' },
+    ],
+    outdoor: [
+      { name: 'Weighted Step-up', sets: 4, reps: '12/leg' },
+      { name: 'Sled Push', sets: 6, reps: '20m' },
+      { name: 'Sprint Acceleration', sets: 6, reps: '50m' },
+    ],
+  },
+  hamstrings: {
+    label: 'Hamstrings',
+    category: 'legs',
+    gym: [
+      { name: 'Romanian Deadlift', sets: 4, reps: '8–10', main: true },
+      { name: 'Nordic Curl', sets: 3, reps: '6–8' },
+      { name: 'Seated Leg Curl', sets: 4, reps: '12–15' },
+    ],
+    home: [
+      { name: 'Single-leg Romanian Deadlift', sets: 4, reps: '10/leg' },
+      { name: 'Sliding Leg Curl', sets: 3, reps: '12' },
+      { name: 'Band Good Morning', sets: 3, reps: '20' },
+    ],
+    outdoor: [
+      { name: 'Glute-ham Raise Bench', sets: 3, reps: '10' },
+      { name: 'Sprint Drills (A/B)', sets: 4, reps: '30m' },
+      { name: 'Sandbag Romanian Deadlift', sets: 3, reps: '15' },
+    ],
+  },
+  calves: {
+    label: 'Calves',
+    category: 'legs',
+    gym: [
+      { name: 'Seated Calf Raise', sets: 4, reps: '15–20' },
+      { name: 'Leg Press Calf Raise', sets: 4, reps: '20' },
+      { name: 'Single-leg Standing Calf Raise', sets: 3, reps: '15' },
+    ],
+    home: [
+      { name: 'Tempo Calf Raise', sets: 4, reps: '20' },
+      { name: 'Farmer Walk on Toes', sets: 3, reps: '30m' },
+      { name: 'Jump Rope Burst', sets: 3, reps: '60s' },
+    ],
+    outdoor: [
+      { name: 'Up-stair Bounding', sets: 6, reps: '1 flight' },
+      { name: 'Weighted March on Toes', sets: 4, reps: '40m' },
+      { name: 'Beach Sprint', sets: 5, reps: '60m' },
+    ],
+  },
+};
+
+const MUSCLE_LAYOUT = [
+  { id: 'chest', label: 'Chest', path: 'M85 85 Q100 55 115 85 Q118 105 110 150 Q100 160 90 150 Z', side: 'front' },
+  { id: 'shoulders', label: 'Shoulders', path: 'M70 60 Q100 20 130 60 Q120 70 100 70 Q80 70 70 60 Z', side: 'front' },
+  { id: 'triceps', label: 'Triceps', path: 'M60 110 Q55 150 70 180 Q80 150 75 110 Z', side: 'front' },
+  { id: 'back', label: 'Back', path: 'M85 85 Q100 45 115 85 Q120 125 115 180 Q100 190 85 180 Z', side: 'back' },
+  { id: 'biceps', label: 'Biceps', path: 'M130 110 Q135 150 120 180 Q110 150 115 110 Z', side: 'front' },
+  { id: 'forearms', label: 'Forearms', path: 'M52 180 Q48 220 60 260 Q70 220 66 180 Z', side: 'front' },
+  { id: 'core', label: 'Core', path: 'M92 150 Q100 140 108 150 Q110 185 100 220 Q90 185 92 150 Z', side: 'front' },
+  { id: 'glutes', label: 'Glutes', path: 'M85 220 Q100 200 115 220 Q118 250 100 270 Q82 250 85 220 Z', side: 'back' },
+  { id: 'quads', label: 'Quads', path: 'M92 220 Q100 210 108 220 Q112 270 100 320 Q88 270 92 220 Z', side: 'front' },
+  { id: 'hamstrings', label: 'Hamstrings', path: 'M88 220 Q100 215 112 220 Q115 280 100 330 Q85 280 88 220 Z', side: 'back' },
+  { id: 'calves', label: 'Calves', path: 'M95 320 Q100 310 105 320 Q110 360 100 400 Q90 360 95 320 Z', side: 'front' },
+];
+
+/* -------------------------------------------------------------------------- */
+/* Utility functions                                                           */
+/* -------------------------------------------------------------------------- */
+
+const baseDate = new Date('2025-01-01T00:00:00Z');
+const dayIndexFromDate = (date) => Math.floor((date - baseDate) / 86400000);
+const randomFrom = (items, rand) => items[Math.floor(rand() * items.length) % items.length];
+const seededRandom = (seed) => {
   let s = seed;
-  function rand(){ s = Math.sin(s) * 10000; return s - Math.floor(s); }
-  const accessories = Array.from({length: accessoriesCount}, (_, i) => ({
-    name: `Acc${i}-${Math.floor(rand()*1000)}`
-  }));
-  return { compound: { sets: compoundSets }, accessories };
+  return () => {
+    s = Math.sin(s) * 10000;
+    return s - Math.floor(s);
+  };
+};
+
+const roundDuration = (minutes) => Math.min(70, Math.round(minutes));
+
+function adjustSetsForLevel(exercises, level, intensityBias = 1) {
+  const factor = (level === 'Beginner' ? 0.8 : level === 'Intermediate' ? 1 : 1.25) * intensityBias;
+  return exercises.map((exercise) => {
+    if (!exercise.sets) return exercise;
+    const baseSets = typeof exercise.sets === 'number' ? exercise.sets : parseInt(String(exercise.sets).split('×')[0], 10) || exercise.sets;
+    const adjustedSets = Math.max(2, Math.round(baseSets * factor));
+    return { ...exercise, sets: adjustedSets };
+  });
 }
-const FINISHERS = { default: [{ name: 'Jumping Jacks' }] };
-if (typeof module !== 'undefined') { module.exports = { generateDailyPlan, FINISHERS }; }
+
+function ensurePlanDuration(plan) {
+  const base = 10; // warm-up
+  const hiit = 7;
+  const perSet = 3.5;
+  const accessories = plan.blocks.flatMap((block) => block.exercises || []);
+  const totalSets = accessories.reduce((acc, ex) => acc + (typeof ex.sets === 'number' ? ex.sets : 1), 0);
+  const estimated = base + hiit + totalSets * perSet;
+  const updatedPlan = { ...plan, estimatedMinutes: roundDuration(estimated) };
+  if (updatedPlan.estimatedMinutes > 70) {
+    updatedPlan.blocks = updatedPlan.blocks.map((block) => {
+      if (!block.exercises) return block;
+      return {
+        ...block,
+        exercises: block.exercises.map((exercise) => {
+          if (typeof exercise.sets === 'number' && exercise.sets > 2) {
+            return { ...exercise, sets: exercise.sets - 1 };
+          }
+          return exercise;
+        }),
+      };
+    });
+    const reducedSets = updatedPlan.blocks.flatMap((block) => block.exercises || [])
+      .reduce((acc, ex) => acc + (typeof ex.sets === 'number' ? ex.sets : 1), 0);
+    updatedPlan.estimatedMinutes = roundDuration(base + hiit + reducedSets * perSet);
+  }
+  return updatedPlan;
+}
+
+function buildCalisthenicsBlock(rand, intensityBias = 1, level = 'Beginner') {
+  const shuffled = [...CALISTHENICS_MOVES].sort(() => rand() - 0.5);
+  const baseSets = level === 'Beginner' ? 2 : level === 'Intermediate' ? 3 : 4;
+  const sets = Math.max(2, Math.round(baseSets * intensityBias));
+  return {
+    title: 'Calisthenics mastery',
+    type: 'calisthenics',
+    exercises: shuffled.slice(0, 4).map((move) => ({ ...move, sets, reps: move.reps || '8–12' })),
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Plan generator                                                              */
+/* -------------------------------------------------------------------------- */
+
+class WorkoutLibrary {
+  constructor() {
+    this.hiit = HIIT_LIBRARY;
+  }
+
+  getCalisthenicsBlock(rand, intensityBias, level) {
+    return buildCalisthenicsBlock(rand, intensityBias, level);
+  }
+
+  getGymPlan(format, mode) {
+    return GYM_LIBRARY[format][mode];
+  }
+
+  getHomePlan(equipment, split) {
+    if (equipment === 'minimal') return HOME_LIBRARY.minimal.total;
+    if (equipment === 'calisthenics') return HOME_LIBRARY.calisthenics.flow;
+    return HOME_LIBRARY.dumbbell[split];
+  }
+
+  getOutdoorPlan(equipment) {
+    return OUTDOOR_LIBRARY[equipment].plan;
+  }
+
+  buildCustomForMuscles(muscles, context) {
+    const exercises = [];
+    muscles.forEach((muscle) => {
+      const catalog = CUSTOM_LIBRARY[muscle];
+      if (!catalog) return;
+      exercises.push(...catalog[context]);
+    });
+    return exercises;
+  }
+}
+
+class PlanGenerator {
+  constructor(library) {
+    this.library = library;
+  }
+
+  generate(date = new Date(), options = {}) {
+    const {
+      style = 'gym',
+      level = 'Beginner',
+      goal = 'strength',
+      equipment = 'freeweight',
+      intensityBias = 1,
+      customMuscles = [],
+    } = options;
+
+    const selectedMuscles = Array.isArray(customMuscles)
+      ? customMuscles.slice(0, 3)
+      : [];
+
+    const dayIndex = dayIndexFromDate(date);
+    const rand = seededRandom(dayIndex + 1);
+    const rotationPhase = dayIndex % 6;
+
+    let plan;
+    if (style === 'custom') {
+      plan = this.generateCustomPlan({ customMuscles: selectedMuscles, level, intensityBias, rand, equipment });
+    } else if (style === 'gym') {
+      plan = this.generateGymPlan({ rotationPhase, level, intensityBias, rand });
+    } else if (style === 'home') {
+      plan = this.generateHomePlan({ rotationPhase, level, intensityBias, equipment, rand });
+    } else {
+      plan = this.generateOutdoorPlan({ rotationPhase, level, intensityBias, equipment, rand });
+    }
+
+    const hiit = randomFrom(this.library.hiit, rand);
+    const calisthenicsBlock = plan.blocks.find((b) => b.type === 'calisthenics');
+    if (calisthenicsBlock) {
+      calisthenicsBlock.exercises = calisthenicsBlock.exercises.map((exercise) => ({
+        ...exercise,
+        reps: exercise.reps || '6–10',
+      }));
+    }
+
+    const goalFocus = GOAL_FOCUS[goal] || GOAL_FOCUS.strength;
+    const finalPlan = ensurePlanDuration({
+      ...plan,
+      style,
+      level,
+      goal,
+      equipment,
+      goalFocus,
+      hiit,
+      date: date.toISOString().slice(0, 10),
+      intensityBias,
+      customMuscles: plan.customMuscles || selectedMuscles,
+      selection: selectedMuscles,
+    });
+    return finalPlan;
+  }
+
+  generateGymPlan({ rotationPhase, level, intensityBias, rand }) {
+    const order = ['push', 'pull', 'legs', 'push', 'pull', 'legs'];
+    const format = order[rotationPhase % order.length];
+    const mode = rotationPhase % 6 < 3 ? 'volume' : 'size';
+    const raw = this.library.getGymPlan(format, mode);
+    const adjusted = adjustSetsForLevel(raw, level, intensityBias).map((exercise) => {
+      if (mode === 'volume' && typeof exercise.sets === 'number') {
+        return { ...exercise, tempo: 'Controlled 3-1-1', rest: '90s' };
+      }
+      if (mode === 'size' && typeof exercise.sets === 'number') {
+        return { ...exercise, tempo: 'Explosive concentric', rest: '75s' };
+      }
+      return exercise;
+    });
+    return {
+      format,
+      mode,
+      blocks: [
+        { title: 'Primary lifts', exercises: adjusted.slice(0, 3) },
+        { title: 'Accessory rotation', exercises: adjusted.slice(3) },
+        this.library.getCalisthenicsBlock(rand, intensityBias, level),
+      ],
+    };
+  }
+
+  generateHomePlan({ rotationPhase, level, intensityBias, equipment, rand }) {
+    if (equipment === 'calisthenics') {
+      return {
+        format: 'calisthenics',
+        mode: 'skill',
+        blocks: [this.library.getCalisthenicsBlock(rand, intensityBias, level)],
+      };
+    }
+    if (equipment === 'minimal') {
+      const plan = this.library.getHomePlan('minimal');
+      return {
+        format: 'total body',
+        mode: 'bodyweight',
+        blocks: [
+          { title: 'Full-body flow', exercises: adjustSetsForLevel(plan, level, intensityBias) },
+          this.library.getCalisthenicsBlock(rand, intensityBias, level),
+        ],
+      };
+    }
+    const split = rotationPhase % 2 === 0 ? 'upper' : 'lower';
+    const plan = this.library.getHomePlan('dumbbell', split);
+    return {
+      format: split,
+      mode: 'dumbbell',
+      blocks: [
+        { title: `${split === 'upper' ? 'Upper' : 'Lower'} power`, exercises: adjustSetsForLevel(plan, level, intensityBias) },
+        this.library.getCalisthenicsBlock(rand, intensityBias, level),
+      ],
+    };
+  }
+
+  generateOutdoorPlan({ level, intensityBias, equipment, rand }) {
+    if (equipment === 'calisthenics') {
+      return {
+        format: 'calisthenics',
+        mode: 'skill',
+        blocks: [this.library.getCalisthenicsBlock(rand, intensityBias, level)],
+      };
+    }
+    const plan = this.library.getOutdoorPlan(equipment);
+    return {
+      format: equipment,
+      mode: 'endurance',
+      blocks: [
+        { title: equipment === 'running' ? 'Track session' : 'Pool session', exercises: adjustSetsForLevel(plan, level, intensityBias) },
+        this.library.getCalisthenicsBlock(rand, intensityBias, level),
+      ],
+    };
+  }
+
+  generateCustomPlan({ customMuscles, level, intensityBias, rand, equipment }) {
+    const muscles = customMuscles.length ? customMuscles : ['chest', 'back'];
+    const context = equipment === 'machines' || equipment === 'freeweight' ? 'gym'
+      : equipment === 'dumbbell' || equipment === 'minimal' || equipment === 'calisthenics' ? 'home'
+      : 'outdoor';
+    const exercises = this.library.buildCustomForMuscles(muscles, context);
+    const accessoryBlock = adjustSetsForLevel(exercises.slice(3), level, intensityBias);
+    const mainBlock = adjustSetsForLevel(exercises.slice(0, 3), level, intensityBias).map((exercise) => ({
+      ...exercise,
+      main: true,
+    }));
+
+    const categories = new Set(muscles.map((id) => CUSTOM_LIBRARY[id]?.category).filter(Boolean));
+    let format = 'custom';
+    if (categories.has('push') && categories.size === 1) format = 'push';
+    else if (categories.has('pull') && categories.size === 1) format = 'pull';
+    else if (categories.has('legs') && categories.size === 1) format = 'legs';
+
+    const blocks = [
+      { title: 'Primary focus', exercises: mainBlock },
+    ];
+    if (accessoryBlock.length) {
+      blocks.push({ title: 'Volume builder', exercises: accessoryBlock });
+    }
+    blocks.push(this.library.getCalisthenicsBlock(rand, intensityBias, level));
+
+    return {
+      format,
+      mode: 'muscle-selection',
+      blocks,
+      customMuscles: muscles,
+    };
+  }
+}
+
+const library = new WorkoutLibrary();
+const generator = new PlanGenerator(library);
+
+function generateWorkoutPlan(date = new Date(), options = {}) {
+  return generator.generate(date, options);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Profile + History management                                               */
+/* -------------------------------------------------------------------------- */
+
+class ProfileManager {
+  constructor(store) {
+    this.store = store;
+    this.state = this.load();
+  }
+
+  load() {
+    const defaults = {
+      user: { name: 'Warrior' },
+      lang: 'en',
+      style: 'gym',
+      lastGuidedStyle: 'gym',
+      level: 'Beginner',
+      goal: 'strength',
+      equipment: 'freeweight',
+      format: 'push',
+      intensityBias: 1,
+      logs: [],
+      planCache: {},
+      customMuscles: [],
+      sessionCounts: { Beginner: 0, Intermediate: 0, Advanced: 0 },
+    };
+    const saved = this.store.load('profile', {});
+    return {
+      ...defaults,
+      ...saved,
+      sessionCounts: { ...defaults.sessionCounts, ...(saved.sessionCounts || {}) },
+    };
+  }
+
+  persist() {
+    this.store.save('profile', this.state);
+  }
+
+  recordSession(plan, feedback, weights, notes) {
+    const previousLevel = this.state.level;
+    const entry = {
+      date: new Date().toISOString().slice(0, 10),
+      plan,
+      feedback,
+      weights,
+      notes,
+      mainLiftWeight: this.determineMainLiftWeight(weights, plan),
+    };
+    this.state.logs = this.state.logs.filter((log) => log.date !== entry.date);
+    this.state.logs.push(entry);
+    this.bumpSessionCounter();
+    const levelUp = this.state.level !== previousLevel ? { from: previousLevel, to: this.state.level } : null;
+    this.persist();
+    return { entry, levelUp };
+  }
+
+  bumpSessionCounter() {
+    const currentLevel = this.state.level;
+    const today = todayKey();
+    const todayPlan = this.state.planCache?.[today];
+    if (!this.state.sessionCounts[currentLevel]) this.state.sessionCounts[currentLevel] = 0;
+    this.state.sessionCounts[currentLevel] += 1;
+
+    const threshold = LEVEL_THRESHOLDS[currentLevel];
+    if (threshold && this.state.sessionCounts[currentLevel] >= threshold) {
+      if (currentLevel === 'Beginner') {
+        this.state.level = 'Intermediate';
+      } else if (currentLevel === 'Intermediate') {
+        this.state.level = 'Advanced';
+      }
+      this.state.sessionCounts[currentLevel] = 0;
+      this.state.sessionCounts[this.state.level] = this.state.sessionCounts[this.state.level] || 0;
+      this.state.planCache = todayPlan ? { [today]: todayPlan } : {};
+    }
+  }
+
+  determineMainLiftWeight(weights, plan) {
+    const mainIndices = [];
+    plan.blocks.forEach((block, blockIndex) => {
+      (block.exercises || []).forEach((exercise, index) => {
+        if (exercise.main) {
+          mainIndices.push({ blockIndex, index });
+        }
+      });
+    });
+    const entries = weights.filter((entry) => mainIndices.some((mi) => mi.blockIndex === entry.block && mi.index === entry.index));
+    if (!entries.length) return null;
+    return entries.reduce((acc, entry) => acc + entry.weight, 0) / entries.length;
+  }
+
+  adjustIntensity(feedback) {
+    if (feedback === 'easy') this.state.intensityBias = Math.min(1.4, this.state.intensityBias + 0.05);
+    if (feedback === 'hard') this.state.intensityBias = Math.max(0.7, this.state.intensityBias - 0.05);
+    this.persist();
+  }
+
+  cachePlan(plan) {
+    const key = plan.date;
+    this.state.planCache[key] = plan;
+    this.persist();
+  }
+
+  loadCachedPlan(dateKey) {
+    return this.state.planCache[dateKey];
+  }
+
+  clearOldPlan(dateKey) {
+    this.state.planCache = { [dateKey]: this.state.planCache[dateKey] };
+    this.persist();
+  }
+
+  updateSelection(updates) {
+    if (Object.prototype.hasOwnProperty.call(updates, 'style')) {
+      if (updates.style && updates.style !== 'custom') {
+        this.state.lastGuidedStyle = updates.style;
+      } else if (!this.state.lastGuidedStyle) {
+        this.state.lastGuidedStyle = 'gym';
+      }
+    }
+    this.state = { ...this.state, ...updates };
+    this.persist();
+  }
+
+  get logs() {
+    return [...this.state.logs];
+  }
+}
+
+const profileManager = new ProfileManager(storageService);
+
+function todayKey() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function ensureTodayPlan() {
+  const key = todayKey();
+  const cached = profileManager.loadCachedPlan(key);
+  const needsRefresh = !cached
+    || cached.style !== profileManager.state.style
+    || cached.level !== profileManager.state.level
+    || cached.goal !== profileManager.state.goal
+    || cached.equipment !== profileManager.state.equipment
+    || JSON.stringify(cached.selection || []) !== JSON.stringify(profileManager.state.customMuscles || []);
+
+  if (needsRefresh) {
+    const plan = generateWorkoutPlan(new Date(), profileManager.state);
+    profileManager.cachePlan({ ...plan });
+    return plan;
+  }
+  return cached;
+}
+
+/* -------------------------------------------------------------------------- */
+/* UI: helpers                                                                 */
+/* -------------------------------------------------------------------------- */
+
+const $ = doc ? (selector) => doc.querySelector(selector) : () => null;
+const $$ = doc ? (selector) => Array.from(doc.querySelectorAll(selector)) : () => [];
+
+function fmtTime(date) {
+  return date.toLocaleTimeString('en-IN', {
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Asia/Kolkata',
+  });
+}
+
+function computeStreak(logs) {
+  if (!logs.length) return 0;
+  const sorted = [...logs].sort((a, b) => (a.date < b.date ? 1 : -1));
+  let streak = 0;
+  let prevDate = todayKey();
+  sorted.forEach((entry, idx) => {
+    const date = entry.date;
+    if (idx === 0) {
+      if (date === prevDate) streak = 1;
+      prevDate = date;
+      return;
+    }
+    const diff = Math.floor((new Date(prevDate) - new Date(date)) / 86400000);
+    if (diff === 1) {
+      streak += 1;
+      prevDate = date;
+    }
+  });
+  return streak;
+}
+
+function renderHistory(logs) {
+  if (!doc) return;
+  const list = $('#historyList');
+  if (!list) return;
+  list.innerHTML = '';
+  const sorted = [...logs].sort((a, b) => (a.date > b.date ? -1 : 1)).slice(0, 6);
+  if (!sorted.length) {
+    const empty = doc.createElement('li');
+    empty.textContent = 'No sessions logged yet — your graph will appear here once you complete a workout.';
+    list.appendChild(empty);
+    return;
+  }
+  sorted.forEach((log) => {
+    const item = doc.createElement('li');
+    item.className = 'history__item';
+    const feedbackLabel = log.feedback === 'easy' ? 'Easy' : log.feedback === 'hard' ? 'Hard' : 'Balanced';
+    item.innerHTML = `
+      <div class="history__header">
+        <span>${log.date}</span>
+        <span>${log.plan.style.toUpperCase()} · ${log.plan.format.toUpperCase()}</span>
+      </div>
+      <div class="history__meta">${feedbackLabel} — ${log.plan.estimatedMinutes} min</div>
+    `;
+    list.appendChild(item);
+  });
+}
+
+function renderProgressChart(logs) {
+  if (!doc) return;
+  const canvas = $('#progressChart');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const data = logs
+    .filter((entry) => entry.mainLiftWeight)
+    .sort((a, b) => (a.date > b.date ? 1 : -1));
+
+  if (!data.length) {
+    ctx.fillStyle = 'rgba(255,255,255,0.7)';
+    ctx.font = '14px Inter, sans-serif';
+    ctx.fillText('Log main lift weights to see the graph', 20, canvas.height / 2);
+    return;
+  }
+
+  const padding = 30;
+  const min = Math.min(...data.map((entry) => entry.mainLiftWeight));
+  const max = Math.max(...data.map((entry) => entry.mainLiftWeight));
+  const range = Math.max(10, max - min);
+
+  ctx.strokeStyle = 'rgba(255,255,255,0.2)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(padding, padding);
+  ctx.lineTo(padding, canvas.height - padding);
+  ctx.lineTo(canvas.width - padding, canvas.height - padding);
+  ctx.stroke();
+
+  ctx.strokeStyle = '#6ad4ff';
+  ctx.lineWidth = 3;
+  ctx.beginPath();
+  data.forEach((entry, index) => {
+    const x = padding + (index / Math.max(1, data.length - 1)) * (canvas.width - padding * 2);
+    const y = canvas.height - padding - ((entry.mainLiftWeight - min) / range) * (canvas.height - padding * 2);
+    if (index === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  });
+  ctx.stroke();
+
+  ctx.fillStyle = '#6ad4ff';
+  data.forEach((entry, index) => {
+    const x = padding + (index / Math.max(1, data.length - 1)) * (canvas.width - padding * 2);
+    const y = canvas.height - padding - ((entry.mainLiftWeight - min) / range) * (canvas.height - padding * 2);
+    ctx.beginPath();
+    ctx.arc(x, y, 4, 0, Math.PI * 2);
+    ctx.fill();
+  });
+}
+
+function formatPlanSummary(plan) {
+  if (!plan) return '—';
+  if (plan.style === 'custom' && (plan.customMuscles || []).length) {
+    const labels = (plan.customMuscles || []).map((id) => CUSTOM_LIBRARY[id]?.label || id);
+    return `CUSTOM · ${plan.format?.toUpperCase() || 'FOCUS'} · ${labels.join(' · ')}`;
+  }
+  const focusList = (plan.goalFocus || []).slice(0, 2);
+  const focus = focusList.length ? ` · ${focusList.join(' · ')}` : '';
+  return `${(plan.style || '').toUpperCase()} · ${(plan.format || '').toUpperCase()}${focus}`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Muscle selector UI component                                               */
+/* -------------------------------------------------------------------------- */
+
+class MuscleSelector {
+  constructor(layout, limit = 3) {
+    this.layout = layout;
+    this.limit = limit;
+    this.selected = new Set();
+    this.container = null;
+    this.chipContainer = null;
+    this.statusNode = null;
+    this.limitTimer = null;
+    this.onChange = null;
+  }
+
+  mount(container, statusNode) {
+    if (!doc || !container) return;
+    this.container = container;
+    this.statusNode = statusNode || null;
+    container.innerHTML = '';
+    const svg = doc.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    svg.setAttribute('viewBox', '0 0 200 420');
+    svg.setAttribute('class', 'muscle-map');
+
+    this.layout.forEach((region) => {
+      const path = doc.createElementNS('http://www.w3.org/2000/svg', 'path');
+      path.setAttribute('d', region.path);
+      path.dataset.muscle = region.id;
+      path.setAttribute('class', 'muscle-region');
+      path.addEventListener('click', () => this.toggle(region.id));
+      svg.appendChild(path);
+    });
+
+    container.appendChild(svg);
+    this.renderChipList();
+    this.syncPaths();
+    this.updateChips();
+    this.updateStatus();
+    this.emitChange();
+  }
+
+  toggle(id) {
+    if (this.selected.has(id)) {
+      this.selected.delete(id);
+    } else if (this.selected.size < this.limit) {
+      this.selected.add(id);
+    } else {
+      this.updateStatus();
+      this.flashLimitNotice();
+      return;
+    }
+    this.syncPaths();
+    this.updateChips();
+    this.updateStatus();
+  }
+
+  renderChipList() {
+    if (!this.container) return;
+    this.chipContainer = doc.createElement('div');
+    this.chipContainer.className = 'chip-container';
+    this.container.appendChild(this.chipContainer);
+  }
+
+  updateChips() {
+    if (!this.chipContainer) return;
+    this.chipContainer.innerHTML = '';
+    if (!this.selected.size) {
+      const empty = doc.createElement('span');
+      empty.className = 'chip chip--ghost';
+      empty.textContent = 'Select up to three focus muscles';
+      this.chipContainer.appendChild(empty);
+      return;
+    }
+    Array.from(this.selected).forEach((id) => {
+      const chip = doc.createElement('button');
+      chip.type = 'button';
+      chip.className = 'chip chip--pill';
+      chip.textContent = CUSTOM_LIBRARY[id]?.label || id;
+      chip.addEventListener('click', () => {
+        this.selected.delete(id);
+        this.syncPaths();
+        this.updateChips();
+        this.updateStatus();
+        this.emitChange();
+      });
+      this.chipContainer.appendChild(chip);
+    });
+  }
+
+  syncPaths() {
+    if (!this.container) return;
+    this.container.querySelectorAll('.muscle-region').forEach((node) => {
+      node.classList.toggle('active', this.selected.has(node.dataset.muscle));
+    });
+  }
+
+  updateStatus() {
+    if (!this.statusNode) return;
+    const count = this.selected.size;
+    const remainder = this.limit - count;
+    const suffix = remainder <= 0 ? ' — limit reached' : '';
+    this.statusNode.textContent = `${count} of ${this.limit} focus areas selected${suffix}`;
+    if (count >= this.limit) this.statusNode.classList.add('limit');
+    else this.statusNode.classList.remove('limit');
+  }
+
+  flashLimitNotice() {
+    if (!this.statusNode) return;
+    this.statusNode.classList.add('limit');
+    clearTimeout(this.limitTimer);
+    this.limitTimer = setTimeout(() => {
+      if (this.selected.size < this.limit) {
+        this.statusNode?.classList.remove('limit');
+      }
+    }, 600);
+  }
+
+  value() {
+    return Array.from(this.selected).slice(0, this.limit);
+  }
+
+  setValue(muscles = []) {
+    this.selected = new Set((muscles || []).slice(0, this.limit));
+    this.syncPaths();
+    this.updateChips();
+    this.updateStatus();
+  }
+
+  clear() {
+    this.selected.clear();
+    this.syncPaths();
+    this.updateChips();
+    this.updateStatus();
+    this.emitChange();
+  }
+
+  setOnChange(handler) {
+    this.onChange = handler;
+  }
+
+  emitChange() {
+    if (typeof this.onChange === 'function') {
+      this.onChange(this.value());
+    }
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Planner UI                                                                 */
+/* -------------------------------------------------------------------------- */
+
+class PlannerUI {
+  constructor(profile, planGenerator, muscleSelector) {
+    this.profile = profile;
+    this.generator = planGenerator;
+    this.muscleSelector = muscleSelector;
+    this.currentPlan = null;
+    this.lastGuidedStyle = this.profile.state.lastGuidedStyle
+      || (this.profile.state.style === 'custom' ? 'gym' : this.profile.state.style);
+  }
+
+  init() {
+    if (!doc) return;
+    this.cacheDom();
+    this.bindEvents();
+    this.syncStyleButtons();
+    this.syncCustomBuilder();
+    this.activateStep(0);
+    this.renderWelcome();
+    this.renderPlanScreen();
+    renderHistory(this.profile.logs);
+    renderProgressChart(this.profile.logs);
+    this.tickClock();
+  }
+
+  cacheDom() {
+    this.welcomeScreen = $('#screen-welcome');
+    this.startBtn = $('#btnStartExperience');
+    this.nextStepBtns = $$('.btn-step');
+    this.levelSelect = $('#levelSelect');
+    this.styleButtons = $$('.style-option');
+    this.goalSelect = $('#goalSelect');
+    this.equipmentSelect = $('#equipmentSelect');
+    this.customBuilderPanel = $('#customBuilderPanel');
+    this.muscleContainer = $('#muscleSelector');
+    this.muscleStatusCount = $('#muscleSelectionCount');
+    this.clearMusclesBtn = $('#btnClearMuscles');
+    this.planBlocks = $('#planBlocks');
+    this.hiitList = $('#hiitList');
+    this.goalFocusList = $('#goalFocusList');
+    this.planFocus = $('#planFocus');
+    this.planRotation = $('#planRotation');
+    this.planDuration = $('#planDuration');
+    this.motivationText = $('#motivationQuote');
+    this.stepper = $('#flowStepper');
+    this.stepperItems = this.stepper ? Array.from(this.stepper.querySelectorAll('[data-step]')) : [];
+    this.stepSections = $$('.flow-section');
+  }
+
+  bindEvents() {
+    if (this.startBtn) {
+      this.startBtn.addEventListener('click', () => {
+        this.activateStep(1);
+        this.syncCustomBuilder();
+      });
+    }
+
+    this.nextStepBtns.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const step = Number(btn.dataset.nextStep || '2');
+        if (step === 2) {
+          this.syncCustomBuilder();
+        }
+        if (step === 3) {
+          this.updateStateFromSelectors();
+          this.renderPlanScreen(true);
+        }
+        this.activateStep(step);
+      });
+    });
+
+    if (this.levelSelect) {
+      this.levelSelect.value = this.profile.state.level;
+      this.levelSelect.addEventListener('change', () => {
+        this.profile.updateSelection({ level: this.levelSelect.value });
+        this.renderPlanScreen(true);
+      });
+    }
+
+    if (this.goalSelect) {
+      this.goalSelect.value = this.profile.state.goal;
+      this.goalSelect.addEventListener('change', () => {
+        this.profile.updateSelection({ goal: this.goalSelect.value });
+        this.renderPlanScreen(true);
+      });
+    }
+
+    if (this.equipmentSelect) {
+      this.updateEquipmentOptions();
+      this.equipmentSelect.addEventListener('change', () => {
+        this.profile.updateSelection({ equipment: this.equipmentSelect.value });
+        this.renderPlanScreen(true);
+      });
+    }
+
+    this.styleButtons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const style = btn.dataset.style;
+        this.profile.updateSelection({ style });
+        if (style !== 'custom') {
+          this.lastGuidedStyle = style;
+        }
+        this.syncStyleButtons();
+        this.syncCustomBuilder();
+        this.updateEquipmentOptions();
+        this.renderPlanScreen(true);
+      });
+    });
+
+    if (this.clearMusclesBtn) {
+      this.clearMusclesBtn.addEventListener('click', () => {
+        this.muscleSelector.clear();
+        this.syncCustomBuilder();
+      });
+    }
+
+    $('#btnMarkDone')?.addEventListener('click', () => this.submitFeedback());
+    $('#btnBackHome')?.addEventListener('click', () => this.activateStep(0));
+    $('#linkChangeStyle')?.addEventListener('click', () => this.activateStep(1));
+  }
+
+  syncStyleButtons() {
+    if (!this.styleButtons) return;
+    this.styleButtons.forEach((btn) => {
+      const isActive = btn.dataset.style === this.profile.state.style;
+      btn.classList.toggle('style-option--active', isActive);
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+  }
+
+  syncCustomBuilder() {
+    if (!this.muscleContainer) return;
+    const isCustom = this.profile.state.style === 'custom';
+    this.customBuilderPanel?.classList.toggle('hidden', !isCustom);
+    if (isCustom) {
+      this.muscleSelector.mount(this.muscleContainer, this.muscleStatusCount);
+      this.muscleSelector.setOnChange((muscles) => {
+        this.profile.updateSelection({ customMuscles: muscles });
+        this.renderPlanScreen(true);
+      });
+      this.muscleSelector.setValue(this.profile.state.customMuscles || []);
+    } else {
+      this.muscleSelector.setOnChange(null);
+    }
+  }
+
+  updateStateFromSelectors() {
+    const muscles = this.profile.state.style === 'custom' ? this.muscleSelector.value() : [];
+    this.profile.updateSelection({ customMuscles: muscles });
+  }
+
+  activateStep(step) {
+    if (!doc) return;
+    if (this.stepperItems) {
+      this.stepperItems.forEach((node) => {
+        const nodeStep = Number(node.dataset.step);
+        const isActive = nodeStep === step;
+        node.classList.toggle('active', isActive);
+        node.classList.toggle('completed', nodeStep < step);
+        node.setAttribute('aria-current', isActive ? 'step' : 'false');
+      });
+    }
+
+    if (this.stepSections) {
+      this.stepSections.forEach((section) => {
+        const sectionStep = Number(section.dataset.stepSection);
+        const isActive = sectionStep === step;
+        section.classList.toggle('hidden', !isActive);
+        section.setAttribute('aria-hidden', String(!isActive));
+      });
+      const current = this.stepSections.find((section) => Number(section.dataset.stepSection) === step);
+      if (current) {
+        if (typeof current.scrollIntoView === 'function') {
+          current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }
+        setTimeout(() => {
+          if (typeof current.focus === 'function') {
+            current.focus();
+          }
+        }, 200);
+      }
+    }
+  }
+
+  tickClock() {
+    if (!doc) return;
+    const node = $('#timeVal');
+    if (node) node.textContent = fmtTime(new Date());
+    setTimeout(() => this.tickClock(), 60000);
+  }
+
+  renderWelcome() {
+    if (!doc) return;
+    $('#welcomeTitle').textContent = `Welcome back, ${this.profile.state.user.name}`;
+    $('#streakVal').textContent = computeStreak(this.profile.logs);
+    const lastLog = [...this.profile.logs].sort((a, b) => (a.date < b.date ? 1 : -1))[0];
+    $('#lastWorkoutVal').textContent = lastLog ? `${lastLog.plan.style} · ${lastLog.plan.format}` : '—';
+    $('#lastStyleChip').textContent = formatPlanSummary(ensureTodayPlan());
+    $('#motivationQuote').textContent = randomFrom(MOTIVATIONAL_QUOTES, Math.random);
+  }
+
+  updateEquipmentOptions() {
+    if (!doc || !this.equipmentSelect) return;
+    const options = this.profile.state.style === 'custom'
+      ? CUSTOM_EQUIPMENT_OPTIONS
+      : (EQUIPMENT_VARIANTS[this.profile.state.style] || ['freeweight']);
+    this.equipmentSelect.innerHTML = '';
+    options.forEach((option) => {
+      const opt = doc.createElement('option');
+      opt.value = option;
+      opt.textContent = option.charAt(0).toUpperCase() + option.slice(1);
+      this.equipmentSelect.appendChild(opt);
+    });
+    if (!options.includes(this.profile.state.equipment)) {
+      this.profile.updateSelection({ equipment: options[0] });
+    }
+    this.equipmentSelect.value = this.profile.state.equipment;
+  }
+
+  renderPlanScreen(force = false) {
+    if (!doc) return;
+    if (!force && this.currentPlan) return;
+    this.currentPlan = ensureTodayPlan();
+    if (force) {
+      this.currentPlan = generateWorkoutPlan(new Date(), this.profile.state);
+      this.profile.cachePlan({ ...this.currentPlan });
+    }
+    this.drawPlan(this.currentPlan);
+    if (force) {
+      this.renderWelcome();
+    }
+  }
+
+  drawPlan(plan) {
+    if (!doc) return;
+    this.planBlocks.innerHTML = '';
+    this.planFocus.textContent = formatPlanSummary(plan);
+    const baseMode = plan.mode || 'focus';
+    const rotationLabel = plan.mode === 'muscle-selection'
+      ? 'Custom muscle rotation'
+      : `${baseMode.charAt(0).toUpperCase() + baseMode.slice(1)} rotation`;
+    this.planRotation.textContent = rotationLabel;
+    this.planDuration.textContent = `${plan.estimatedMinutes} minutes`;
+
+    this.goalFocusList.innerHTML = '';
+    plan.goalFocus.forEach((item) => {
+      const li = doc.createElement('li');
+      li.textContent = item;
+      this.goalFocusList.appendChild(li);
+    });
+
+    plan.blocks.forEach((block, blockIndex) => {
+      const section = doc.createElement('section');
+      section.className = 'card workout-block';
+      section.innerHTML = `
+        <header class="card__header">
+          <h3 class="headline-sm">${block.title}</h3>
+        </header>
+      `;
+      const list = doc.createElement('ol');
+      list.className = 'exercise-list';
+      (block.exercises || []).forEach((exercise, exerciseIndex) => {
+        const item = doc.createElement('li');
+        item.innerHTML = `
+          <div class="exercise-name">${exercise.name}${exercise.main ? ' · <span class="tag">Main</span>' : ''}</div>
+          <div class="exercise-meta">${exercise.sets ? `${exercise.sets} sets` : ''} ${exercise.reps ? `· ${exercise.reps}` : ''}</div>
+        `;
+        const weightInput = doc.createElement('input');
+        weightInput.type = 'number';
+        weightInput.placeholder = 'Load (kg)';
+        weightInput.className = 'input weight-input';
+        weightInput.dataset.block = blockIndex;
+        weightInput.dataset.index = exerciseIndex;
+        item.appendChild(weightInput);
+        list.appendChild(item);
+      });
+      section.appendChild(list);
+      this.planBlocks.appendChild(section);
+    });
+
+    this.hiitList.innerHTML = '';
+    plan.hiit.forEach((movement) => {
+      const li = doc.createElement('li');
+      li.textContent = movement;
+      this.hiitList.appendChild(li);
+    });
+  }
+
+  collectWeights() {
+    const weights = [];
+    $$('.weight-input').forEach((input) => {
+      if (input.value) {
+        weights.push({ block: Number(input.dataset.block), index: Number(input.dataset.index), weight: Number(input.value) });
+      }
+    });
+    return weights;
+  }
+
+  submitFeedback() {
+    const plan = this.currentPlan || ensureTodayPlan();
+    const weights = this.collectWeights();
+    const feedback = $('input[name="feedback"]:checked')?.value || 'good';
+    const notes = $('#feedbackNotes').value.trim();
+    const { levelUp } = this.profile.recordSession(plan, feedback, weights, notes);
+    this.profile.adjustIntensity(feedback);
+    renderHistory(this.profile.logs);
+    renderProgressChart(this.profile.logs);
+    this.renderWelcome();
+    if (this.levelSelect) {
+      this.levelSelect.value = this.profile.state.level;
+    }
+    let message = 'Feedback stored. Tomorrow’s plan will adapt.';
+    if (levelUp) {
+      message += ` Level advanced from ${levelUp.from} to ${levelUp.to}.`;
+      this.renderPlanScreen(true);
+    }
+    alert(message);
+    this.activateStep(0);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Bootstrapping                                                              */
+/* -------------------------------------------------------------------------- */
+
+if (doc) {
+  const muscleSelector = new MuscleSelector(MUSCLE_LAYOUT);
+  const planner = new PlannerUI(profileManager, generator, muscleSelector);
+  planner.init();
+}
+
+module.exports = {
+  generateWorkoutPlan,
+  HIIT_LIBRARY,
+  CALISTHENICS_MOVES,
+  CUSTOM_LIBRARY,
+  MOTIVATIONAL_QUOTES,
+};

--- a/index.html
+++ b/index.html
@@ -1,96 +1,205 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Yodha Arc — MVP</title>
-  <link rel="stylesheet" href="styles.css" />
-</head>
-<body>
-    <header class="appbar">
-      <div class="appbar__title" data-i18n="appTitle">Yodha Arc — Forge Your Steel</div>
-      <div class="appbar__actions">
-        <button id="btnMenu" class="icon-btn" aria-label="Menu" title="Menu">☰</button>
-      </div>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Yodha Arc — Adaptive Coach</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="neo-appbar">
+      <div class="neo-brand">Yodha Arc</div>
+      <div class="neo-sub">Adaptive training intelligence</div>
     </header>
 
-    <div id="menuOverlay" class="menu-overlay"></div>
-    <nav id="menu" class="menu">
-      <button id="btnMenuClose" class="icon-btn menu__close" aria-label="Close menu">✕</button>
-      <select id="languageSelect" aria-label="Language">
-        <option value="en">English</option>
-        <option value="te">తెలుగు</option>
-      </select>
-      <button id="btnSettings" class="btn menu-item" data-i18n="settings">Settings</button>
-    </nav>
-
     <main id="app" class="viewport">
-      <!-- Welcome -->
-      <section id="screen-welcome" class="screen" data-screen="welcome">
-        <h2 id="welcomeTitle" class="headline"></h2>
-        <div class="card stats">
-          <div class="stat"><div class="stat__label" data-i18n="streak">Streak</div><div id="streakVal" class="stat__value">0</div></div>
-          <div class="stat"><div class="stat__label" data-i18n="lastWorkout">Last workout</div><div id="lastWorkoutVal" class="stat__value">—</div></div>
-          <div class="stat"><div class="stat__label" data-i18n="time">Time (IST)</div><div id="timeVal" class="stat__value">—</div></div>
+      <section id="screen-welcome" class="screen">
+        <div class="hero-panel">
+          <div class="hero-copy">
+            <h1 id="welcomeTitle" class="hero-title">Welcome back, Warrior</h1>
+            <p id="motivationQuote" class="hero-quote">Steel is forged under pressure—so are you.</p>
+            <button id="btnStartExperience" class="btn btn-primary btn-lg">Launch today’s arc</button>
+          </div>
+          <div class="hero-stats">
+            <div class="stat-card">
+              <span class="stat-label">Streak</span>
+              <span id="streakVal" class="stat-value">0</span>
+            </div>
+            <div class="stat-card">
+              <span class="stat-label">Last workout</span>
+              <span id="lastWorkoutVal" class="stat-value">—</span>
+            </div>
+            <div class="stat-card">
+              <span class="stat-label">Time (IST)</span>
+              <span id="timeVal" class="stat-value">—</span>
+            </div>
+            <div class="stat-card">
+              <span class="stat-label">Today’s focus</span>
+              <span id="lastStyleChip" class="chip">—</span>
+            </div>
+          </div>
         </div>
-        <div class="stack mt">
-          <button id="btnChooseStyle" class="btn btn-primary" data-i18n="chooseStyle">Choose Workout Style</button>
-          <button id="btnContinueLast" class="btn btn-ghost"><span data-i18n="continueLast">Continue last:</span> <span id="lastStyleChip">—</span></button>
-        </div>
-      </section>
 
-      <!-- Gym Session -->
-      <section id="screen-gym" class="screen" data-screen="gym" hidden>
-        <div class="row between">
-          <h2 class="headline" data-i18n="gymSessionTitle">Today’s Gym Session</h2>
-          <button class="link" id="linkChangeStyle" data-i18n="changeStyle">Change style</button>
-      </div>
-      <p class="sub" data-i18n="gymWarmup">Warm-up (8–10 min): joint prep + ramp sets for the compound.</p>
-      <div class="row mt">
-        <label for="formatSelect">Workout:</label>
-        <select id="formatSelect">
-          <option value="pull">Pull</option>
-          <option value="push">Push</option>
-          <option value="legs">Legs</option>
-        </select>
-      </div>
-      <div id="gymPlan" class="stack"></div>
-      <h3 class="headline mt" data-i18n="finisherTitle">Superman Finisher</h3>
-      <p class="sub" data-i18n="finisherSub">7-minute loop: 15 Jumping Jacks → 12 Swings → 10 DB Snatches (5/arm) → 20 Mountain Climbers.</p>
-      <div class="timer card">
-        <div id="timerDisplay" class="timer__display">07:00</div>
-        <div class="row">
-          <button id="btnStartTimer" class="btn btn-primary" data-i18n="start">Start</button>
-          <button id="btnPauseTimer" class="btn btn-secondary" data-i18n="pause">Pause</button>
-          <button id="btnResetTimer" class="btn btn-ghost" data-i18n="reset">Reset</button>
+        <div id="flowStepper" class="flow-stepper">
+          <div class="flow-stepper__item active" data-step="0">Welcome</div>
+          <div class="flow-stepper__item" data-step="1">Experience</div>
+          <div class="flow-stepper__item" data-step="2">Level & Goal</div>
+          <div class="flow-stepper__item" data-step="3">Plan & Log</div>
         </div>
-      </div>
-        <div class="stack mt">
-          <button id="btnMarkDone" class="btn btn-success" data-i18n="markDone">Mark workout complete</button>
-          <button id="btnBackHome" class="btn btn-ghost" data-i18n="back">Back</button>
-        </div>
+
+        <section id="step-landing" class="flow-section" data-step-section="0" aria-hidden="false" tabindex="-1">
+          <div class="grid two">
+            <article class="card translucent">
+              <header class="card__header">
+                <h2 class="headline-sm">Main lift progress</h2>
+              </header>
+              <canvas id="progressChart" width="480" height="240" class="chart"></canvas>
+            </article>
+            <article class="card translucent">
+              <header class="card__header">
+                <h2 class="headline-sm">Recent history</h2>
+              </header>
+              <ul id="historyList" class="history"></ul>
+            </article>
+          </div>
+        </section>
+
+        <section id="step-experience" class="flow-section hidden" data-step-section="1" aria-hidden="true" tabindex="-1">
+          <div class="card translucent">
+            <header class="card__header">
+              <h2 class="headline-sm">Choose today’s experience</h2>
+              <p class="sub">Rotate through environments or craft a bespoke muscle day.</p>
+            </header>
+            <div class="style-grid">
+              <button type="button" class="style-option" data-style="gym" aria-pressed="false">
+                <span class="style-title">Gym Forge</span>
+                <span class="style-desc">Machines · Free weights · Calisthenics</span>
+              </button>
+              <button type="button" class="style-option" data-style="home" aria-pressed="false">
+                <span class="style-title">Home Stronghold</span>
+                <span class="style-desc">Minimal kit · Dumbbells · Flow</span>
+              </button>
+              <button type="button" class="style-option" data-style="outdoor" aria-pressed="false">
+                <span class="style-title">Outdoor Hunt</span>
+                <span class="style-desc">Run · Swim · Calisthenics</span>
+              </button>
+              <button type="button" class="style-option style-option--custom" data-style="custom" aria-pressed="false">
+                <span class="style-title">Custom Sculpt</span>
+                <span class="style-desc">Tap muscles · Mix PPL · Total freedom</span>
+              </button>
+            </div>
+            <div class="stack mt hidden" id="customBuilderPanel">
+              <p class="sub">Tap up to three focus areas on the anatomy map to craft a bespoke split.</p>
+              <div class="muscle-toolbar">
+                <span id="muscleSelectionCount" class="muscle-toolbar__count">0 of 3 focus areas selected</span>
+                <button type="button" id="btnClearMuscles" class="btn btn-ghost btn-xs">Clear selection</button>
+              </div>
+              <div id="muscleSelector" class="muscle-selector"></div>
+            </div>
+            <div class="actions">
+              <button class="btn btn-ghost btn-step" data-next-step="0">Cancel</button>
+              <button class="btn btn-primary btn-step" data-next-step="2">Next</button>
+            </div>
+          </div>
+        </section>
+
+        <section id="step-level" class="flow-section hidden" data-step-section="2" aria-hidden="true" tabindex="-1">
+          <div class="card translucent">
+            <header class="card__header">
+              <h2 class="headline-sm">Dial in your profile</h2>
+              <p class="sub">Complete 30 beginner sessions to unlock Intermediate, then 40 more to reach Advanced.</p>
+            </header>
+            <div class="grid two">
+              <label class="field">
+                <span>Level</span>
+                <select id="levelSelect" class="input">
+                  <option value="Beginner">Beginner</option>
+                  <option value="Intermediate">Intermediate</option>
+                  <option value="Advanced">Advanced</option>
+                </select>
+              </label>
+              <label class="field">
+                <span>Primary goal</span>
+                <select id="goalSelect" class="input">
+                  <option value="strength">Strength</option>
+                  <option value="hypertrophy">Hypertrophy</option>
+                  <option value="fatloss">Fat Loss</option>
+                  <option value="endurance">Endurance</option>
+                </select>
+              </label>
+            </div>
+            <label class="field mt">
+              <span>Equipment focus</span>
+              <select id="equipmentSelect" class="input"></select>
+            </label>
+            <div class="actions">
+              <button class="btn btn-ghost btn-step" data-next-step="1">Back</button>
+              <button class="btn btn-primary btn-step" data-next-step="3">Preview plan</button>
+            </div>
+          </div>
+        </section>
+
+        <section id="step-plan" class="flow-section hidden" data-step-section="3" aria-hidden="true" tabindex="-1">
+          <div class="card translucent">
+            <header class="card__header">
+              <div>
+                <h2 class="headline-sm">Session breakdown</h2>
+                <p class="sub">Warm-up 10 min · HIIT finisher 7 min — capped at 70 total minutes.</p>
+              </div>
+              <button class="btn btn-ghost btn-step" data-next-step="1">Change</button>
+            </header>
+            <dl class="summary">
+              <div class="summary__item">
+                <dt>Focus</dt>
+                <dd id="planFocus">—</dd>
+              </div>
+              <div class="summary__item">
+                <dt>Rotation</dt>
+                <dd id="planRotation">—</dd>
+              </div>
+              <div class="summary__item">
+                <dt>Estimated duration</dt>
+                <dd id="planDuration">—</dd>
+              </div>
+            </dl>
+            <h4 class="headline-xs">Goal cues</h4>
+            <ul id="goalFocusList" class="bullet"></ul>
+            <section class="card nested mt">
+              <header class="card__header">
+                <h3 class="headline-sm">Warm-up (10 min)</h3>
+              </header>
+              <p>Joint mobilisations · Breathing drills · Ramped sets of the main lift.</p>
+            </section>
+            <section id="planBlocks" class="stack mt"></section>
+            <section class="card nested mt">
+              <header class="card__header">
+                <h3 class="headline-sm">Mandatory 7-minute HIIT Finisher</h3>
+                <p class="sub">60 seconds work · 5 seconds transition.</p>
+              </header>
+              <ol id="hiitList" class="hiit-list"></ol>
+            </section>
+            <section class="card nested mt">
+              <header class="card__header">
+                <h3 class="headline-sm">Dial-in feedback</h3>
+              </header>
+              <fieldset class="feedback-group">
+                <legend>How did today feel?</legend>
+                <label><input type="radio" name="feedback" value="easy" /> Too Easy</label>
+                <label><input type="radio" name="feedback" value="good" checked /> Just Right</label>
+                <label><input type="radio" name="feedback" value="hard" /> Too Tough</label>
+              </fieldset>
+              <textarea id="feedbackNotes" rows="3" class="input" placeholder="Notes, energy, anything worth remembering…"></textarea>
+              <div class="actions mt">
+                <button id="btnMarkDone" class="btn btn-success">Mark workout complete</button>
+                <button id="btnBackHome" class="btn btn-ghost">Back to dashboard</button>
+              </div>
+            </section>
+          </div>
+        </section>
       </section>
     </main>
-
-    <!-- Style selection modal -->
-    <div id="styleModal" class="style-modal" hidden>
-      <h2 class="headline" data-i18n="styleHeadline">How do you want to train today?</h2>
-      <p class="sub" data-i18n="styleSub">Pick one. You can change this anytime.</p>
-      <label for="levelSelect" class="mt">Level:</label>
-      <select id="levelSelect" class="mt">
-        <option value="Intermediate">Intermediate</option>
-        <option value="Advanced">Advanced</option>
-      </select>
-      <div class="grid mt">
-        <button class="style-card" data-style="gym"><div class="style-title" data-i18n="styleGymTitle">Gym Workout</div><div class="style-desc" data-i18n="styleGymDesc">Full equipment. Barbell/Machines OK.</div></button>
-        <button class="style-card" data-style="home"><div class="style-title" data-i18n="styleHomeTitle">Home Workout</div><div class="style-desc" data-i18n="styleHomeDesc">Bodyweight + DB/KB. Minimal gear.</div></button>
-        <button class="style-card" data-style="cardio"><div class="style-title" data-i18n="styleCardioTitle">Cardio</div><div class="style-desc" data-i18n="styleCardioDesc">25–40 min steady or intervals.</div></button>
-        <button class="style-card" data-style="recovery"><div class="style-title" data-i18n="styleRecoveryTitle">Active Recovery</div><div class="style-desc" data-i18n="styleRecoveryDesc">Mobility + easy movement.</div></button>
-      </div>
-      <button id="styleClose" class="btn btn-ghost mt" data-i18n="back">Back</button>
-    </div>
 
     <footer class="footer">© 2025 Yodha Arc</footer>
     <script src="app.js"></script>
   </body>
-  </html>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "yodha-arc",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "preview": "node preview.js",
+    "test": "node tests/test.js"
+  }
+}

--- a/preview.js
+++ b/preview.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * Minimal static preview server for Yodha Arc.
+ *
+ * Serves the repository root over HTTP so the service worker and relative
+ * asset paths behave exactly as they do in production. No dependencies
+ * required – just Node's standard library.
+ */
+
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname);
+const PORT = Number(process.env.PORT || 4173);
+
+const MIME_TYPES = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.webmanifest': 'application/manifest+json; charset=utf-8',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+function sendFile(res, filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  const type = MIME_TYPES[ext] || 'application/octet-stream';
+  const stream = fs.createReadStream(filePath);
+  stream.on('error', (error) => {
+    res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end(`Error reading ${filePath}: ${error.message}`);
+  });
+  res.writeHead(200, { 'Content-Type': type });
+  stream.pipe(res);
+}
+
+function handleRequest(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host}`);
+  const pathname = decodeURIComponent(url.pathname);
+  let requestedPath = path.join(ROOT, pathname);
+
+  if (!requestedPath.startsWith(ROOT)) {
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Forbidden');
+    return;
+  }
+
+  fs.stat(requestedPath, (err, stats) => {
+    if (!err && stats.isDirectory()) {
+      requestedPath = path.join(requestedPath, 'index.html');
+    }
+
+    fs.stat(requestedPath, (statErr, stat) => {
+      if (statErr || !stat.isFile()) {
+        const fallback = path.join(ROOT, 'index.html');
+        if (requestedPath === fallback) {
+          res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+          res.end('Not found');
+          return;
+        }
+        sendFile(res, fallback);
+        return;
+      }
+
+      sendFile(res, requestedPath);
+    });
+  });
+}
+
+const server = http.createServer(handleRequest);
+
+server.listen(PORT, () => {
+  console.log(`\nYodha Arc preview running at http://localhost:${PORT}\n`);
+});
+
+process.on('SIGINT', () => {
+  console.log('\nShutting down preview server.');
+  server.close(() => process.exit(0));
+});

--- a/styles.css
+++ b/styles.css
@@ -1,116 +1,468 @@
 * { box-sizing: border-box; }
-:root { --header-height:56px; --footer-height:40px; }
-html, body { height:100%; overflow:hidden; }
+:root {
+  --bg: radial-gradient(circle at 20% -10%, #13294b, #05070f 65%);
+  --panel: rgba(13, 22, 34, 0.78);
+  --panel-strong: rgba(23, 37, 59, 0.92);
+  --border: rgba(148, 163, 184, 0.2);
+  --accent: #5be9ff;
+  --accent-strong: #38bdf8;
+  --text: #f8fafc;
+  --muted: rgba(226, 232, 240, 0.7);
+  --success: #22c55e;
+  --shadow: 0 20px 60px rgba(15, 23, 42, 0.45);
+  --radius: 24px;
+}
+
+html, body { height: 100%; }
 body {
-  margin:0;
-  height:100%;
-  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial, "Noto Sans", "Nirmala UI";
-  color:#0f172a;
-  background:#f7fafc;
+  margin: 0;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  flex-direction: column;
 }
+
+.neo-appbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  padding: 24px clamp(16px, 5vw, 64px);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: linear-gradient(90deg, rgba(15, 23, 42, 0.9), rgba(2, 6, 23, 0.3));
+  backdrop-filter: blur(22px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.neo-brand {
+  font-size: clamp(24px, 4vw, 32px);
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.neo-sub {
+  font-size: 14px;
+  color: var(--muted);
+}
+
 .viewport {
-  position:fixed;
-  top:var(--header-height);
-  left:0; right:0;
-  height:calc(100dvh - var(--header-height) - var(--footer-height));
-  overflow:hidden;
-  max-width:760px;
-  margin-inline:auto;
-  padding-inline:16px;
-}
-@supports (padding: max(0px)) {
-  .viewport {
-    padding-left:max(16px, env(safe-area-inset-left));
-    padding-right:max(16px, env(safe-area-inset-right));
-  }
+  flex: 1;
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: clamp(16px, 4vw, 48px);
+  padding-bottom: 80px;
 }
 
-/* App bar */
-.appbar {
-  position:fixed; top:0; left:0; right:0; z-index:10;
-  display:flex; align-items:center; justify-content:space-between;
-  height:var(--header-height); padding:0 12px;
-  background:#0b3d91; color:#fff; border-bottom:1px solid #0a357f;
+.screen { display: grid; gap: 32px; }
+
+.hero-panel {
+  display: grid;
+  gap: clamp(24px, 4vw, 48px);
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
 }
-.appbar__title { font-weight: 700; }
-.appbar__actions { display:flex; align-items:center; gap:8px; }
-.icon-btn { background: transparent; color:#fff; border:0; font-size: 20px; cursor:pointer; }
 
-.menu-overlay { position:fixed; inset:0; background:rgba(0,0,0,0.4); opacity:0; visibility:hidden; transition:opacity 0.3s; z-index:15; }
-.menu-overlay.show { opacity:1; visibility:visible; }
-.menu { position:fixed; top:0; right:0; height:100dvh; width:240px; background:#fff; box-shadow:-2px 0 8px rgba(0,0,0,.1); padding:16px; display:flex; flex-direction:column; gap:12px; transform:translateX(100%); transition:transform 0.3s ease; z-index:20; }
-.menu.open { transform:translateX(0); }
-.menu select { height:32px; border-radius:6px; }
-.menu .menu-item { width:100%; }
-.menu__close { align-self:flex-end; background:transparent; border:0; font-size:20px; cursor:pointer; }
-
-/* Screens */
-.screen { padding:16px 0; height:100%; overflow-y:auto; }
-#screen-welcome { display:flex; flex-direction:column; justify-content:center; overflow:hidden; }
-.logo {
-  width: 84px; height: 84px; border-radius: 50%;
-  background: #0b3d91; color:#fff; display: grid; place-items: center;
-  font-weight: 800; font-size: 28px; letter-spacing: 1px; margin: 12px 0;
+.hero-copy {
+  background: var(--panel-strong);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: clamp(24px, 4vw, 48px);
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
 }
-.headline { margin: 6px 0; font-weight: 800; font-size: 22px; color:#0b3d91; }
-.sub { color:#475569; margin: 6px 0 16px; }
 
-/* Controls */
-.btn { display:inline-flex; align-items:center; justify-content:center; gap:8px;
-  min-height:44px; padding:10px 14px; border-radius:10px; border:1px solid transparent; font-weight:700; cursor:pointer; }
-.btn-primary { background:#0b3d91; color:#fff; }
-.btn-secondary { background:#e2e8f0; color:#0f172a; }
-.btn-ghost { background:transparent; color:#0b3d91; border-color:#bcd0ff; }
-.btn-success { background:#16a34a; color:#fff; }
-.link { background:transparent; color:#0b3d91; border:0; text-decoration:underline; cursor:pointer; }
-.input { height:44px; padding:10px 12px; border:1px solid #cbd5e1; border-radius:10px; width:100%; }
+.hero-copy::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 20%, rgba(91, 233, 255, 0.3), transparent 55%);
+  pointer-events: none;
+}
 
-.stack > * + * { margin-top: 10px; }
-.row { display:flex; gap:10px; align-items:center; }
-.row.between { justify-content: space-between; }
+.hero-title {
+  margin: 0 0 12px;
+  font-size: clamp(28px, 5vw, 44px);
+  font-weight: 800;
+  line-height: 1.1;
+}
+
+.hero-quote {
+  margin: 0 0 24px;
+  font-size: clamp(16px, 2.6vw, 20px);
+  color: var(--muted);
+}
+
+.hero-stats {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.stat-card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 18px;
+  display: grid;
+  gap: 8px;
+  box-shadow: var(--shadow);
+}
+
+.stat-label { font-size: 13px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.stat-value { font-size: 24px; font-weight: 700; }
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(91, 233, 255, 0.12);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 6px 16px;
+  font-weight: 600;
+}
+
+.flow-stepper {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.flow-stepper__item {
+  padding: 14px 18px;
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  text-align: center;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--muted);
+  transition: all 0.2s ease;
+}
+
+.flow-stepper__item.active {
+  color: var(--text);
+  border-color: var(--accent);
+  box-shadow: 0 12px 32px rgba(56, 189, 248, 0.25);
+}
+
+.flow-stepper__item.completed {
+  color: rgba(148, 163, 184, 0.9);
+  border-style: dashed;
+}
+
+.flow-section {
+  display: grid;
+  gap: 24px;
+}
+
+.card {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: clamp(20px, 3vw, 36px);
+  box-shadow: var(--shadow);
+}
+
+.card.translucent { background: rgba(15, 23, 42, 0.65); }
+.card.nested {
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 20px;
+  box-shadow: none;
+}
+
+.card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.headline-sm { margin: 0; font-size: 20px; font-weight: 700; }
+.headline-xs { margin: 24px 0 12px; text-transform: uppercase; letter-spacing: 0.12em; font-size: 12px; color: var(--muted); }
+.sub { margin: 6px 0 0; color: var(--muted); font-size: 14px; }
+
+.grid.two { display: grid; gap: 24px; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+
+.history { list-style: none; margin: 0; padding: 0; display: grid; gap: 12px; }
+.history__item {
+  background: rgba(148, 163, 184, 0.1);
+  border-radius: 18px;
+  padding: 14px 18px;
+  display: grid;
+  gap: 6px;
+}
+.history__header { display: flex; justify-content: space-between; font-weight: 600; }
+.history__meta { color: var(--muted); font-size: 13px; }
+
+.chart {
+  width: 100%;
+  background: rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 18px;
+}
+
+.btn {
+  min-height: 48px;
+  border-radius: 999px;
+  padding: 0 28px;
+  border: 1px solid transparent;
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.12s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.btn-lg { min-height: 56px; font-size: 16px; padding-inline: 36px; }
+.btn-xs { min-height: 32px; padding: 0 14px; font-size: 12px; }
+
+.btn-primary {
+  background: linear-gradient(90deg, #38bdf8, #818cf8);
+  color: #0f172a;
+  box-shadow: 0 12px 32px rgba(56, 189, 248, 0.35);
+}
+
+.btn-primary:hover { transform: translateY(-2px); }
+
+.btn-success {
+  background: linear-gradient(90deg, #22c55e, #4ade80);
+  color: #052e16;
+  box-shadow: 0 12px 32px rgba(34, 197, 94, 0.35);
+}
+
+.btn-ghost {
+  background: transparent;
+  border-color: rgba(148, 163, 184, 0.4);
+  color: var(--muted);
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 24px;
+}
+
+.style-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  margin-top: 16px;
+}
+
+.style-option {
+  display: grid;
+  gap: 6px;
+  padding: 20px;
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.45);
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  transition: transform 0.15s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.style-option:hover {
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+
+.style-option--active {
+  border-color: var(--accent);
+  box-shadow: 0 16px 40px rgba(56, 189, 248, 0.2);
+}
+.style-option--custom { background: linear-gradient(145deg, rgba(56, 189, 248, 0.18), rgba(129, 140, 248, 0.12)); }
+
+.style-title { font-size: 18px; font-weight: 700; }
+.style-desc { color: var(--muted); font-size: 13px; }
+
+.input, select, textarea {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 12px 14px;
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  font-size: 14px;
+  font-family: inherit;
+}
+
+.field { display: grid; gap: 8px; }
+
+.toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 24px;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.toggle input {
+  appearance: none;
+  width: 48px;
+  height: 24px;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  position: relative;
+  background: rgba(15, 23, 42, 0.6);
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.toggle input::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.9);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.toggle input:checked {
+  background: rgba(59, 130, 246, 0.4);
+  border-color: #38bdf8;
+}
+
+.toggle input:checked::after {
+  transform: translateX(22px);
+  background: #38bdf8;
+}
+
+.toggle__label { font-size: 14px; }
+
+.muscle-selector {
+  display: grid;
+  justify-content: center;
+  padding: 12px;
+  background: rgba(15, 23, 42, 0.5);
+  border-radius: 20px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+}
+
+.muscle-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.muscle-toolbar__count {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.muscle-toolbar__count.limit {
+  color: var(--accent);
+}
+
+.muscle-map {
+  width: min(280px, 70vw);
+  height: auto;
+}
+
+.muscle-region {
+  fill: rgba(148, 163, 184, 0.3);
+  stroke: rgba(148, 163, 184, 0.6);
+  stroke-width: 1.5;
+  cursor: pointer;
+  transition: fill 0.2s ease, stroke 0.2s ease;
+}
+
+.muscle-region:hover { fill: rgba(91, 233, 255, 0.35); stroke: #5be9ff; }
+.muscle-region.active { fill: rgba(91, 233, 255, 0.65); stroke: #38bdf8; }
+
+.chip-container { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+.chip--ghost { background: rgba(148, 163, 184, 0.12); color: var(--muted); padding: 6px 12px; border-radius: 999px; }
+.chip--pill {
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  border-radius: 999px;
+  padding: 6px 16px;
+  color: var(--accent);
+  cursor: pointer;
+}
+
+.summary {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  margin: 0 0 16px;
+}
+
+.summary__item { display: grid; gap: 6px; }
+.summary__item dt { font-size: 12px; text-transform: uppercase; letter-spacing: 0.12em; color: var(--muted); }
+.summary__item dd { margin: 0; font-weight: 600; font-size: 16px; }
+
+.stack { display: grid; gap: 12px; }
 .mt { margin-top: 16px; }
 
-.card { background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:12px; box-shadow:0 1px 2px rgba(0,0,0,.04); }
-
-/* Stats */
-.stats { display:flex; gap:12px; }
-.stat { flex:1; text-align:center; }
-.stat__label { color:#64748b; font-size:12px; }
-.stat__value { font-weight:800; font-size:18px; color:#0b3d91; }
-
-/* Style select grid */
-.grid { display:grid; grid-template-columns:1fr 1fr; gap:12px; }
-.style-card { text-align:left; border:1px solid #e5e7eb; border-radius:12px; padding:14px; background:#fff; }
-.style-title { font-weight:800; color:#0b3d91; margin-bottom:4px; }
-.style-desc { color:#475569; }
-@media (max-width:480px) { .grid { grid-template-columns:1fr; } }
-
-/* Timer */
-.timer { display:flex; align-items:center; justify-content:space-between; flex-wrap:wrap; gap:12px; }
-.timer__display { font-weight:900; font-size:36px; letter-spacing:1px; color:#0b3d91; }
-
-/* Exercise card */
-.exercise { background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:12px; }
-.exercise__title { font-weight:800; color:#0b3d91; margin-bottom:4px; }
-.exercise__meta { color:#334155; font-size:14px; }
-.exercise__notes { color:#475569; font-size:13px; margin-top:6px; }
-
-.style-modal {
-  position:fixed;
-  top:var(--header-height);
-  bottom:var(--footer-height);
-  left:0; right:0;
-  background:#fff;
-  z-index:30;
-  overflow-y:auto;
-  padding:16px;
+.exercise-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 16px;
 }
 
-  .footer {
-    position:fixed; bottom:0; left:0; width:100%; height:var(--footer-height);
-    display:flex; align-items:center; justify-content:center;
-    color:#64748b;
-    background:#f7fafc;
-  }
-.or { text-align:center; color:#94a3b8; }
-.footnote { color:#94a3b8; font-size:12px; }
+.exercise-name { font-weight: 600; }
+.exercise-meta { color: var(--muted); font-size: 13px; margin-top: 4px; }
+
+.tag {
+  background: rgba(34, 197, 94, 0.18);
+  color: #4ade80;
+  border-radius: 12px;
+  padding: 2px 8px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.weight-input {
+  margin-top: 10px;
+  background: rgba(15, 23, 42, 0.65);
+}
+
+.hiit-list { margin: 0; padding-left: 20px; display: grid; gap: 6px; }
+
+.feedback-group {
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  border-radius: 16px;
+  padding: 16px;
+  display: grid;
+  gap: 10px;
+}
+
+.feedback-group legend { font-weight: 600; margin-bottom: 6px; }
+.feedback-group label { display: inline-flex; align-items: center; gap: 8px; font-size: 14px; color: var(--muted); }
+
+textarea { resize: vertical; min-height: 96px; }
+
+.footer {
+  padding: 24px;
+  text-align: center;
+  color: rgba(148, 163, 184, 0.6);
+  font-size: 13px;
+}
+
+.hidden { display: none !important; }
+
+@media (max-width: 720px) {
+  .flow-stepper { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .card__header { flex-direction: column; align-items: flex-start; }
+  .actions { justify-content: stretch; }
+  .actions .btn { flex: 1; }
+}

--- a/tests/test.js
+++ b/tests/test.js
@@ -1,60 +1,106 @@
 /*
-  Minimal test harness for the Yodha Arc generator
+  Minimal assertions for the adaptive Yodha Arc planner.
 
-  This script can be executed with ``node tests/test.js``. It imports the
-  ``generateDailyPlan`` function from the parent directory and runs a
-  handful of assertions to verify that core logic behaves as expected.
-
-  Since third‑party testing libraries are unavailable in this environment
-  (e.g. Jest or Mocha), a simple homemade assert function is used. When
-  tests pass, the script outputs a success message; otherwise it throws an
-  error detailing the failure.
+  Run with: `node tests/test.js`
 */
 
-const { generateDailyPlan, FINISHERS } = require('../app');
+const assert = (cond, msg) => { if (!cond) throw new Error(msg); };
 
-function assert(condition, message) {
-  if (!condition) {
-    throw new Error(message);
+const { generateWorkoutPlan, HIIT_LIBRARY, CALISTHENICS_MOVES, CUSTOM_LIBRARY } = require('../app');
+
+function getPlan(dayOffset = 0, overrides = {}) {
+  const date = new Date('2025-01-01T00:00:00Z');
+  date.setUTCDate(date.getUTCDate() + dayOffset);
+  return generateWorkoutPlan(date, overrides);
+}
+
+function testDurations() {
+  for (let i = 0; i < 14; i += 1) {
+    const plan = getPlan(i, { style: 'gym', level: 'Intermediate', goal: 'strength', equipment: 'freeweight' });
+    assert(plan.estimatedMinutes <= 70, `Gym plan day ${i} exceeds 70 minutes`);
+    assert(plan.hiit.length === 7, 'HIIT finisher must be 7 moves');
   }
 }
 
-function runTests() {
-  // Test each day for beginner
-  const dayKeys = ['FoundationA', 'FoundationB', 'FoundationC', 'DetailA', 'DetailB', 'DetailC'];
-  dayKeys.forEach((key) => {
-    const plan = generateDailyPlan(key, 'Beginner');
-    assert(plan.accessories.length === 4, `${key} beginner should have 4 accessories`);
-    assert(plan.compound.sets === 3, `${key} beginner compound should have 3 sets`);
-  });
-  // Test each day for intermediate
-  dayKeys.forEach((key) => {
-    const plan = generateDailyPlan(key, 'Intermediate');
-    assert(plan.accessories.length === 5, `${key} intermediate should have 5 accessories`);
-    assert(plan.compound.sets === 4, `${key} intermediate compound should have 4 sets`);
-  });
-  // Unknown day key should throw
-  let errorThrown = false;
-  try {
-    generateDailyPlan('UnknownDay', 'Beginner');
-  } catch (err) {
-    errorThrown = true;
-  }
-  assert(errorThrown, 'Unknown day should throw an error');
+function testLevelScaling() {
+  const beginner = getPlan(0, { style: 'gym', level: 'Beginner' });
+  const advanced = getPlan(0, { style: 'gym', level: 'Advanced' });
+  const beginnerSets = beginner.blocks.flatMap((b) => b.exercises).reduce((acc, ex) => acc + (ex.sets || 0), 0);
+  const advancedSets = advanced.blocks.flatMap((b) => b.exercises).reduce((acc, ex) => acc + (ex.sets || 0), 0);
+  assert(advancedSets > beginnerSets, 'Advanced should have more total sets than Beginner');
+}
 
-  // Seeded plan determinism
-  const seed1 = 12345;
-  const seed2 = 54321;
-  const plan1a = generateDailyPlan('FoundationA', 'Beginner', seed1);
-  const plan1b = generateDailyPlan('FoundationA', 'Beginner', seed1);
-  const plan2 = generateDailyPlan('FoundationA', 'Beginner', seed2);
-  assert(JSON.stringify(plan1a) === JSON.stringify(plan1b), 'Identical seeds should yield identical plans');
-  assert(JSON.stringify(plan1a) !== JSON.stringify(plan2), 'Different seeds should yield different plans');
+function testRotationVaries() {
+  const day0 = getPlan(0, { style: 'gym' });
+  const day1 = getPlan(1, { style: 'gym' });
+  const day3 = getPlan(3, { style: 'gym' });
+  assert(day0.format !== day1.format || day0.mode !== day1.mode, 'Consecutive gym days should rotate');
+  assert(day0.mode !== day3.mode, 'Phase should shift across rotation');
+}
 
-  // Finisher order
-  const defaultMoves = FINISHERS.default.map((m) => m.name);
-  assert(defaultMoves[0] === 'Jumping Jacks', 'First default finisher move should be Jumping Jacks');
+function testCalisthenicsEverywhere() {
+  const styles = [
+    { style: 'gym', equipment: 'calisthenics' },
+    { style: 'home', equipment: 'calisthenics' },
+    { style: 'outdoor', equipment: 'calisthenics' },
+  ];
+  styles.forEach(({ style, equipment }) => {
+    const plan = getPlan(2, { style, equipment });
+    const calisthenicsBlock = plan.blocks.find((block) => block.type === 'calisthenics');
+    assert(calisthenicsBlock, `${style} should include a calisthenics block`);
+    assert(calisthenicsBlock.exercises.length > 0, 'Calisthenics block should have movements');
+  });
+}
+
+function testHiitLibrary() {
+  assert(Array.isArray(HIIT_LIBRARY) && HIIT_LIBRARY.length >= 3, 'HIIT library needs variety');
+  HIIT_LIBRARY.forEach((sequence) => {
+    assert(sequence.length === 7, 'Every HIIT sequence must have 7 movements');
+  });
+}
+
+function testCalisthenicsCatalog() {
+  assert(CALISTHENICS_MOVES.length >= 6, 'Calisthenics catalog should provide depth');
+}
+
+function testCustomBuilder() {
+  const muscles = ['chest', 'shoulders', 'triceps'];
+  const plan = getPlan(0, {
+    style: 'custom',
+    equipment: 'freeweight',
+    customMuscles: muscles,
+    level: 'Intermediate',
+  });
+  assert(plan.format === 'push', 'Push selection should mark plan as push');
+  assert(JSON.stringify(plan.customMuscles) === JSON.stringify(muscles), 'Plan should echo the chosen muscles in order');
+  assert(JSON.stringify(plan.selection) === JSON.stringify(muscles), 'Selection metadata should mirror chosen muscles');
+  const primary = plan.blocks[0].exercises.map((ex) => ex.name);
+  const libraryExercises = muscles.flatMap((id) => CUSTOM_LIBRARY[id].gym.map((ex) => ex.name));
+  const overlap = primary.filter((name) => libraryExercises.includes(name));
+  assert(overlap.length > 0, 'Custom builder should use chosen muscle exercises');
+  assert(plan.hiit.length === 7, 'Custom plan still enforces HIIT finisher');
+}
+
+function testCustomSelectionLimit() {
+  const plan = getPlan(1, {
+    style: 'custom',
+    equipment: 'machines',
+    customMuscles: ['chest', 'back', 'shoulders', 'triceps'],
+  });
+  assert(plan.customMuscles.length === 3, 'Custom plans should cap muscle focus at three groups');
+  assert(plan.selection.length === 3, 'Stored selection should cap at three muscles');
+}
+
+function run() {
+  testDurations();
+  testLevelScaling();
+  testRotationVaries();
+  testCalisthenicsEverywhere();
+  testHiitLibrary();
+  testCalisthenicsCatalog();
+  testCustomBuilder();
+  testCustomSelectionLimit();
   console.log('All tests passed.');
 }
 
-runTests();
+run();


### PR DESCRIPTION
## Summary
- replace the custom toggle with a dedicated card, anatomy toolbar, and auto-focused stepper to smooth the welcome → plan journey
- tighten the muscle selector and planner integration to cap selections at three muscles, persist metadata, and refresh previews immediately
- document the new workflow, ship a zero-dependency preview server, and expand tests for custom selection handling

## Testing
- node tests/test.js

------
https://chatgpt.com/codex/tasks/task_e_68f2834e9f9483278e4fdbb41a67d1c6